### PR TITLE
Rework of PillarDAO

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "solidity.compileUsingRemoteVersion": "v0.8.18+commit.87f61d96"
+}

--- a/DEPLOYMENTS.md
+++ b/DEPLOYMENTS.md
@@ -4,8 +4,8 @@
 
 | Contract Name | Network | Contract Address | Transaction Hash |  
 | --- | --- | --- |  --- |
-| `MembershipNFT` | `polygon` | [0x96515c38c6542a698Fa6550DD8C7de9BE602953c](https://polygonscan.com/address/0x96515c38c6542a698Fa6550DD8C7de9BE602953c) | [0x5cb3324c294cd003134d7758dadcf3a54dd129dbb284abe5672203129b1ca42d](https://polygonscan.com/tx/0x5cb3324c294cd003134d7758dadcf3a54dd129dbb284abe5672203129b1ca42d) |
-| `PillarDAO` | `polygon` | [0x7D8107C5000aefaa73b4A31e7B9bDC58D3fdE24b](https://polygonscan.com/address/0x7D8107C5000aefaa73b4A31e7B9bDC58D3fdE24b) | [0xe9b81b00a629edfb6a22238730c237c41bfb452b454ec5f9710f0b86cdc3ce03](https://polygonscan.com/tx/0xe9b81b00a629edfb6a22238730c237c41bfb452b454ec5f9710f0b86cdc3ce03) |
+| `MembershipNFT` | `polygon` | [0xFa2d028Ba398C20eE0A7483c00218F91FFEe47c6](https://polygonscan.com/address/0xFa2d028Ba398C20eE0A7483c00218F91FFEe47c6) | [0xc508647eb202be0f6dde65e2f7a1ef884eb738070cc1abfda1a112d3e65b2bee](https://polygonscan.com/tx/0xc508647eb202be0f6dde65e2f7a1ef884eb738070cc1abfda1a112d3e65b2bee) |
+| `PillarDAO` | `polygon` | [0xE9a88F0d543d3a0C14E487bed884B3dA49529e48](https://polygonscan.com/address/0xE9a88F0d543d3a0C14E487bed884B3dA49529e48) | [0x6a719efb47eb6c3f3d78627e3f934aeb87a432572e0c31d20e18576a3b58348a](https://polygonscan.com/tx/0x6a719efb47eb6c3f3d78627e3f934aeb87a432572e0c31d20e18576a3b58348a) |
 | `PillarStaking` | `polygon` | [0x527569794781671319f20374A050BDbef4181aB3](https://polygonscan.com/address/0x527569794781671319f20374a050bdbef4181ab3) | [0xf2d23e8c8c2bee1c77047c216c73c49a45ddaab50a351f544579d694d0e0e9c1](https://polygonscan.com/tx/0xf2d23e8c8c2bee1c77047c216c73c49a45ddaab50a351f544579d694d0e0e9c1) |
 
 ## Testnets

--- a/contracts/IPillarDAO.sol
+++ b/contracts/IPillarDAO.sol
@@ -12,7 +12,12 @@ interface IPillarDAO {
         uint256 indexed membershipId
     );
 
+    event DepositTimestampSet(address member, uint256 timestamp);
+
+
     function deposit(uint256 _amount) external;
 
     function withdraw() external;
+
+    function setDepositTimestamp(address _member, uint256 _timestamp) external;
 }

--- a/contracts/PillarDAO.sol
+++ b/contracts/PillarDAO.sol
@@ -27,7 +27,7 @@ contract PillarDAO is IPillarDAO, Ownable, ReentrancyGuard {
         address _stakingToken,
         uint256 _stakeAmount,
         address _membershipNft,
-        address[9] memory _preExistingMembers
+        address[] memory _preExistingMembers
     ) {
         require(
             _stakingToken != address(0),
@@ -37,6 +37,9 @@ contract PillarDAO is IPillarDAO, Ownable, ReentrancyGuard {
         stakingToken = _stakingToken;
         stakeAmount = _stakeAmount;
         membershipNFT = MembershipNFT(_membershipNft);
+        for(uint256 i; i < _preExistingMembers.length; i++) {
+            require(_preExistingMembers[i] != address(0), "PillarDAO: invalid pre-existing member");
+        }
         _addExistingMembers(_preExistingMembers);
     }
 
@@ -128,52 +131,24 @@ contract PillarDAO is IPillarDAO, Ownable, ReentrancyGuard {
         membershipNFT = MembershipNFT(_newAddr);
     }
 
-    function _addExistingMembers(address[9] memory _members) internal {
-        // pre-add existing DAO members [9]
-        memberships[_members[0]] = 1;
-        balances[_members[0]] = Deposit({
+    function setDepositTimestamp(address _member, uint256 _timestamp) external onlyOwner {
+        require(_member != address(0), "PillarDAO: invalid member");
+        require(_timestamp != 0, "PillarDAO: invalid timestamp");
+        balances[_member].depositTime = _timestamp;
+        emit DepositTimestampSet(_member, _timestamp);
+    }
+
+    function viewDepositTimestamp(address _member) public view returns(uint256) {
+        return balances[_member].depositTime;
+    }
+
+    function _addExistingMembers(address[] memory _members) internal {
+        for(uint256 i; i < _members.length; i++) {
+            memberships[_members[i]] = i + 1;
+        balances[_members[i]] = Deposit({
             depositAmount: 10000 ether,
             depositTime: block.timestamp
         });
-        memberships[_members[1]] = 2;
-        balances[_members[1]] = Deposit({
-            depositAmount: 10000 ether,
-            depositTime: block.timestamp
-        });
-        memberships[_members[2]] = 3;
-        balances[_members[2]] = Deposit({
-            depositAmount: 10000 ether,
-            depositTime: block.timestamp
-        });
-        memberships[_members[3]] = 4;
-        balances[_members[3]] = Deposit({
-            depositAmount: 10000 ether,
-            depositTime: block.timestamp
-        });
-        memberships[_members[4]] = 5;
-        balances[_members[4]] = Deposit({
-            depositAmount: 10000 ether,
-            depositTime: block.timestamp
-        });
-        memberships[_members[5]] = 6;
-        balances[_members[5]] = Deposit({
-            depositAmount: 10000 ether,
-            depositTime: block.timestamp
-        });
-        memberships[_members[6]] = 7;
-        balances[_members[6]] = Deposit({
-            depositAmount: 10000 ether,
-            depositTime: block.timestamp
-        });
-        memberships[_members[7]] = 8;
-        balances[_members[7]] = Deposit({
-            depositAmount: 10000 ether,
-            depositTime: block.timestamp
-        });
-        memberships[_members[8]] = 9;
-        balances[_members[8]] = Deposit({
-            depositAmount: 10000 ether,
-            depositTime: block.timestamp
-        });
+        }
     }
 }

--- a/contracts/PillarDAO.sol
+++ b/contracts/PillarDAO.sol
@@ -26,7 +26,8 @@ contract PillarDAO is IPillarDAO, Ownable, ReentrancyGuard {
     constructor(
         address _stakingToken,
         uint256 _stakeAmount,
-        address _membershipNft
+        address _membershipNft,
+        address[9] memory _preExistingMembers
     ) {
         require(
             _stakingToken != address(0),
@@ -36,7 +37,7 @@ contract PillarDAO is IPillarDAO, Ownable, ReentrancyGuard {
         stakingToken = _stakingToken;
         stakeAmount = _stakeAmount;
         membershipNFT = MembershipNFT(_membershipNft);
-        // _addExistingMembers();
+        _addExistingMembers(_preExistingMembers);
     }
 
     function deposit(uint256 _amount) external override nonReentrant {
@@ -127,32 +128,52 @@ contract PillarDAO is IPillarDAO, Ownable, ReentrancyGuard {
         membershipNFT = MembershipNFT(_newAddr);
     }
 
-    // function _addExistingMembers() internal {
-    //     // pre-add existing DAO members [5]
-    //     memberships[0x49E2a5d77Fa210403864f74e6556f17a8FcF70b3] = 1;
-    //     balances[0x49E2a5d77Fa210403864f74e6556f17a8FcF70b3] = Deposit({
-    //         depositAmount: 10000 ether,
-    //         depositTime: block.timestamp
-    //     });
-    //     memberships[0x16736E6dcbBD6C1137B31E8f3609A7dC9d626563] = 2;
-    //     balances[0x16736E6dcbBD6C1137B31E8f3609A7dC9d626563] = Deposit({
-    //         depositAmount: 10000 ether,
-    //         depositTime: block.timestamp
-    //     });
-    //     memberships[0x91dF363df3aAB23F8aC22b135662cEDD336f81fb] = 3;
-    //     balances[0x91dF363df3aAB23F8aC22b135662cEDD336f81fb] = Deposit({
-    //         depositAmount: 10000 ether,
-    //         depositTime: block.timestamp
-    //     });
-    //     memberships[0x699A05C81aa37a067a7ad88e8aDf04F975a651d7] = 4;
-    //     balances[0x699A05C81aa37a067a7ad88e8aDf04F975a651d7] = Deposit({
-    //         depositAmount: 10000 ether,
-    //         depositTime: block.timestamp
-    //     });
-    //     memberships[0xb1E6C220925bb475C694E896645f5636C0D019dc] = 5;
-    //     balances[0xb1E6C220925bb475C694E896645f5636C0D019dc] = Deposit({
-    //         depositAmount: 10000 ether,
-    //         depositTime: block.timestamp
-    //     });
-    // }
+    function _addExistingMembers(address[9] memory _members) internal {
+        // pre-add existing DAO members [9]
+        memberships[_members[0]] = 1;
+        balances[_members[0]] = Deposit({
+            depositAmount: 10000 ether,
+            depositTime: block.timestamp
+        });
+        memberships[_members[1]] = 2;
+        balances[_members[1]] = Deposit({
+            depositAmount: 10000 ether,
+            depositTime: block.timestamp
+        });
+        memberships[_members[2]] = 3;
+        balances[_members[2]] = Deposit({
+            depositAmount: 10000 ether,
+            depositTime: block.timestamp
+        });
+        memberships[_members[3]] = 4;
+        balances[_members[3]] = Deposit({
+            depositAmount: 10000 ether,
+            depositTime: block.timestamp
+        });
+        memberships[_members[4]] = 5;
+        balances[_members[4]] = Deposit({
+            depositAmount: 10000 ether,
+            depositTime: block.timestamp
+        });
+        memberships[_members[5]] = 6;
+        balances[_members[5]] = Deposit({
+            depositAmount: 10000 ether,
+            depositTime: block.timestamp
+        });
+        memberships[_members[6]] = 7;
+        balances[_members[6]] = Deposit({
+            depositAmount: 10000 ether,
+            depositTime: block.timestamp
+        });
+        memberships[_members[7]] = 8;
+        balances[_members[7]] = Deposit({
+            depositAmount: 10000 ether,
+            depositTime: block.timestamp
+        });
+        memberships[_members[8]] = 9;
+        balances[_members[8]] = Deposit({
+            depositAmount: 10000 ether,
+            depositTime: block.timestamp
+        });
+    }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,15 +13,16 @@
         "hardhat-gas-reporter": "1.0.7"
       },
       "devDependencies": {
+        "@nomicfoundation/hardhat-network-helpers": "^1.0.9",
         "@nomiclabs/hardhat-ethers": "2.0.4",
         "@nomiclabs/hardhat-waffle": "2.0.2",
         "@openzeppelin/test-helpers": "0.5.16",
         "chai": "4.3.6",
         "ethereum-waffle": "3.4.0",
         "ethers": "5.5.4",
-        "hardhat": "2.8.2",
+        "hardhat": "^2.13.0",
         "hardhat-tracer": "1.1.0-rc.9",
-        "solidity-coverage": "^0.7.20"
+        "solidity-coverage": "0.7.20"
       }
     },
     "node_modules/@babel/runtime": {
@@ -417,64 +418,14 @@
         "node": ">=10.0"
       }
     },
-    "node_modules/@ethereumjs/block": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/@ethereumjs/block/-/block-3.6.1.tgz",
-      "integrity": "sha512-o5d/zpGl4SdVfdTfrsq9ZgYMXddc0ucKMiFW5OphBCX+ep4xzYnSjboFcZXT2V/tcSBr84VrKWWp21CGVb3DGw==",
-      "dependencies": {
-        "@ethereumjs/common": "^2.6.1",
-        "@ethereumjs/tx": "^3.5.0",
-        "ethereumjs-util": "^7.1.4",
-        "merkle-patricia-tree": "^4.2.3"
-      }
-    },
-    "node_modules/@ethereumjs/blockchain": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@ethereumjs/blockchain/-/blockchain-5.5.1.tgz",
-      "integrity": "sha512-JS2jeKxl3tlaa5oXrZ8mGoVBCz6YqsGG350XVNtHAtNZXKk7pU3rH4xzF2ru42fksMMqzFLzKh9l4EQzmNWDqA==",
-      "dependencies": {
-        "@ethereumjs/block": "^3.6.0",
-        "@ethereumjs/common": "^2.6.0",
-        "@ethereumjs/ethash": "^1.1.0",
-        "debug": "^2.2.0",
-        "ethereumjs-util": "^7.1.3",
-        "level-mem": "^5.0.1",
-        "lru-cache": "^5.1.1",
-        "semaphore-async-await": "^1.5.1"
-      }
-    },
-    "node_modules/@ethereumjs/blockchain/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/@ethereumjs/blockchain/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-    },
     "node_modules/@ethereumjs/common": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/@ethereumjs/common/-/common-2.6.1.tgz",
       "integrity": "sha512-eUe5RsYiOnazszPsgQOdaetCwgVquiiQHBpB59xNABOrBPNh/ZdTJz+uhHGzKvPm6Dr91ViBGYZcdclTgtki0g==",
+      "dev": true,
       "dependencies": {
         "crc-32": "^1.2.0",
         "ethereumjs-util": "^7.1.4"
-      }
-    },
-    "node_modules/@ethereumjs/ethash": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@ethereumjs/ethash/-/ethash-1.1.0.tgz",
-      "integrity": "sha512-/U7UOKW6BzpA+Vt+kISAoeDie1vAvY4Zy2KF5JJb+So7+1yKmJeJEHOGSnQIj330e9Zyl3L5Nae6VZyh2TJnAA==",
-      "dependencies": {
-        "@ethereumjs/block": "^3.5.0",
-        "@types/levelup": "^4.3.0",
-        "buffer-xor": "^2.0.1",
-        "ethereumjs-util": "^7.1.1",
-        "miller-rabin": "^4.0.0"
       }
     },
     "node_modules/@ethereumjs/rlp": {
@@ -493,6 +444,7 @@
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/@ethereumjs/tx/-/tx-3.5.0.tgz",
       "integrity": "sha512-/+ZNbnJhQhXC83Xuvy6I9k4jT5sXiV0tMR9C+AzSSpcCV64+NB8dTE1m3x98RYMqb8+TLYWA+HML4F5lfXTlJw==",
+      "dev": true,
       "dependencies": {
         "@ethereumjs/common": "^2.6.1",
         "ethereumjs-util": "^7.1.4"
@@ -522,25 +474,6 @@
         "@noble/hashes": "1.3.1",
         "@scure/bip32": "1.3.1",
         "@scure/bip39": "1.2.1"
-      }
-    },
-    "node_modules/@ethereumjs/vm": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethereumjs/vm/-/vm-5.7.0.tgz",
-      "integrity": "sha512-1ruJ6nmWYsh42I1cseIuzgCSU1MH8Bh3FSJnSNAYoS1HVmr87mB6FyIZa/OvO3W0hKYD6+/t5OsyKrq0v43fAQ==",
-      "dependencies": {
-        "@ethereumjs/block": "^3.6.0",
-        "@ethereumjs/blockchain": "^5.5.1",
-        "@ethereumjs/common": "^2.6.1",
-        "@ethereumjs/tx": "^3.5.0",
-        "async-eventemitter": "^0.2.4",
-        "core-js-pure": "^3.0.1",
-        "debug": "^4.3.3",
-        "ethereumjs-util": "^7.1.4",
-        "functional-red-black-tree": "^1.0.1",
-        "mcl-wasm": "^0.7.1",
-        "merkle-patricia-tree": "^4.2.3",
-        "rustbn.js": "~0.2.0"
       }
     },
     "node_modules/@ethersproject/abi": {
@@ -1212,6 +1145,51 @@
         "@ethersproject/strings": "^5.5.0"
       }
     },
+    "node_modules/@fastify/busboy": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.0.tgz",
+      "integrity": "sha512-+KpH+QxZU7O4675t3mnkQKcZZg56u+K/Ct2K+N2AZYNVK8kyeo/bI18tI8aPm3tvNNRyTWfj6s5tnGNlcbQRsA==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@metamask/eth-sig-util": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@metamask/eth-sig-util/-/eth-sig-util-4.0.1.tgz",
+      "integrity": "sha512-tghyZKLHZjcdlDqCA3gNZmLeR0XvOE9U1qoQO9ohyAZT6Pya+H9vkBPcsyXytmYLNgVoin7CKCmweo/R43V+tQ==",
+      "dependencies": {
+        "ethereumjs-abi": "^0.6.8",
+        "ethereumjs-util": "^6.2.1",
+        "ethjs-util": "^0.1.6",
+        "tweetnacl": "^1.0.3",
+        "tweetnacl-util": "^0.15.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@metamask/eth-sig-util/node_modules/@types/bn.js": {
+      "version": "4.11.6",
+      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
+      "integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@metamask/eth-sig-util/node_modules/ethereumjs-util": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
+      "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
+      "dependencies": {
+        "@types/bn.js": "^4.11.3",
+        "bn.js": "^4.11.0",
+        "create-hash": "^1.1.2",
+        "elliptic": "^6.5.2",
+        "ethereum-cryptography": "^0.1.3",
+        "ethjs-util": "0.1.6",
+        "rlp": "^2.2.3"
+      }
+    },
     "node_modules/@noble/curves": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.1.0.tgz",
@@ -1235,6 +1213,17 @@
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
+    },
+    "node_modules/@noble/secp256k1": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.1.tgz",
+      "integrity": "sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ]
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -1269,6 +1258,360 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@nomicfoundation/ethereumjs-block": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-block/-/ethereumjs-block-4.2.2.tgz",
+      "integrity": "sha512-atjpt4gc6ZGZUPHBAQaUJsm1l/VCo7FmyQ780tMGO8QStjLdhz09dXynmhwVTy5YbRr0FOh/uX3QaEM0yIB2Zg==",
+      "dependencies": {
+        "@nomicfoundation/ethereumjs-common": "3.1.2",
+        "@nomicfoundation/ethereumjs-rlp": "4.0.3",
+        "@nomicfoundation/ethereumjs-trie": "5.0.5",
+        "@nomicfoundation/ethereumjs-tx": "4.1.2",
+        "@nomicfoundation/ethereumjs-util": "8.0.6",
+        "ethereum-cryptography": "0.1.3"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@nomicfoundation/ethereumjs-blockchain": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-blockchain/-/ethereumjs-blockchain-6.2.2.tgz",
+      "integrity": "sha512-6AIB2MoTEPZJLl6IRKcbd8mUmaBAQ/NMe3O7OsAOIiDjMNPPH5KaUQiLfbVlegT4wKIg/GOsFH7XlH2KDVoJNg==",
+      "dependencies": {
+        "@nomicfoundation/ethereumjs-block": "4.2.2",
+        "@nomicfoundation/ethereumjs-common": "3.1.2",
+        "@nomicfoundation/ethereumjs-ethash": "2.0.5",
+        "@nomicfoundation/ethereumjs-rlp": "4.0.3",
+        "@nomicfoundation/ethereumjs-trie": "5.0.5",
+        "@nomicfoundation/ethereumjs-util": "8.0.6",
+        "abstract-level": "^1.0.3",
+        "debug": "^4.3.3",
+        "ethereum-cryptography": "0.1.3",
+        "level": "^8.0.0",
+        "lru-cache": "^5.1.1",
+        "memory-level": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@nomicfoundation/ethereumjs-common": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-common/-/ethereumjs-common-3.1.2.tgz",
+      "integrity": "sha512-JAEBpIua62dyObHM9KI2b4wHZcRQYYge9gxiygTWa3lNCr2zo+K0TbypDpgiNij5MCGNWP1eboNfNfx1a3vkvA==",
+      "dependencies": {
+        "@nomicfoundation/ethereumjs-util": "8.0.6",
+        "crc-32": "^1.2.0"
+      }
+    },
+    "node_modules/@nomicfoundation/ethereumjs-ethash": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-ethash/-/ethereumjs-ethash-2.0.5.tgz",
+      "integrity": "sha512-xlLdcICGgAYyYmnI3r1t0R5fKGBJNDQSOQxXNjVO99JmxJIdXR5MgPo5CSJO1RpyzKOgzi3uIFn8agv564dZEQ==",
+      "dependencies": {
+        "@nomicfoundation/ethereumjs-block": "4.2.2",
+        "@nomicfoundation/ethereumjs-rlp": "4.0.3",
+        "@nomicfoundation/ethereumjs-util": "8.0.6",
+        "abstract-level": "^1.0.3",
+        "bigint-crypto-utils": "^3.0.23",
+        "ethereum-cryptography": "0.1.3"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@nomicfoundation/ethereumjs-evm": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-evm/-/ethereumjs-evm-1.3.2.tgz",
+      "integrity": "sha512-I00d4MwXuobyoqdPe/12dxUQxTYzX8OckSaWsMcWAfQhgVDvBx6ffPyP/w1aL0NW7MjyerySPcSVfDJAMHjilw==",
+      "dependencies": {
+        "@nomicfoundation/ethereumjs-common": "3.1.2",
+        "@nomicfoundation/ethereumjs-util": "8.0.6",
+        "@types/async-eventemitter": "^0.2.1",
+        "async-eventemitter": "^0.2.4",
+        "debug": "^4.3.3",
+        "ethereum-cryptography": "0.1.3",
+        "mcl-wasm": "^0.7.1",
+        "rustbn.js": "~0.2.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@nomicfoundation/ethereumjs-rlp": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-rlp/-/ethereumjs-rlp-4.0.3.tgz",
+      "integrity": "sha512-DZMzB/lqPK78T6MluyXqtlRmOMcsZbTTbbEyAjo0ncaff2mqu/k8a79PBcyvpgAhWD/R59Fjq/x3ro5Lof0AtA==",
+      "bin": {
+        "rlp": "bin/rlp"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@nomicfoundation/ethereumjs-statemanager": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-statemanager/-/ethereumjs-statemanager-1.0.5.tgz",
+      "integrity": "sha512-CAhzpzTR5toh/qOJIZUUOnWekUXuRqkkzaGAQrVcF457VhtCmr+ddZjjK50KNZ524c1XP8cISguEVNqJ6ij1sA==",
+      "dependencies": {
+        "@nomicfoundation/ethereumjs-common": "3.1.2",
+        "@nomicfoundation/ethereumjs-rlp": "4.0.3",
+        "@nomicfoundation/ethereumjs-trie": "5.0.5",
+        "@nomicfoundation/ethereumjs-util": "8.0.6",
+        "debug": "^4.3.3",
+        "ethereum-cryptography": "0.1.3",
+        "functional-red-black-tree": "^1.0.1"
+      }
+    },
+    "node_modules/@nomicfoundation/ethereumjs-trie": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-trie/-/ethereumjs-trie-5.0.5.tgz",
+      "integrity": "sha512-+8sNZrXkzvA1NH5F4kz5RSYl1I6iaRz7mAZRsyxOm0IVY4UaP43Ofvfp/TwOalFunurQrYB5pRO40+8FBcxFMA==",
+      "dependencies": {
+        "@nomicfoundation/ethereumjs-rlp": "4.0.3",
+        "@nomicfoundation/ethereumjs-util": "8.0.6",
+        "ethereum-cryptography": "0.1.3",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@nomicfoundation/ethereumjs-tx": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-tx/-/ethereumjs-tx-4.1.2.tgz",
+      "integrity": "sha512-emJBJZpmTdUa09cqxQqHaysbBI9Od353ZazeH7WgPb35miMgNY6mb7/3vBA98N5lUW/rgkiItjX0KZfIzihSoQ==",
+      "dependencies": {
+        "@nomicfoundation/ethereumjs-common": "3.1.2",
+        "@nomicfoundation/ethereumjs-rlp": "4.0.3",
+        "@nomicfoundation/ethereumjs-util": "8.0.6",
+        "ethereum-cryptography": "0.1.3"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@nomicfoundation/ethereumjs-util": {
+      "version": "8.0.6",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-util/-/ethereumjs-util-8.0.6.tgz",
+      "integrity": "sha512-jOQfF44laa7xRfbfLXojdlcpkvxeHrE2Xu7tSeITsWFgoII163MzjOwFEzSNozHYieFysyoEMhCdP+NY5ikstw==",
+      "dependencies": {
+        "@nomicfoundation/ethereumjs-rlp": "4.0.3",
+        "ethereum-cryptography": "0.1.3"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@nomicfoundation/ethereumjs-vm": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-vm/-/ethereumjs-vm-6.4.2.tgz",
+      "integrity": "sha512-PRTyxZMP6kx+OdAzBhuH1LD2Yw+hrSpaytftvaK//thDy2OI07S0nrTdbrdk7b8ZVPAc9H9oTwFBl3/wJ3w15g==",
+      "dependencies": {
+        "@nomicfoundation/ethereumjs-block": "4.2.2",
+        "@nomicfoundation/ethereumjs-blockchain": "6.2.2",
+        "@nomicfoundation/ethereumjs-common": "3.1.2",
+        "@nomicfoundation/ethereumjs-evm": "1.3.2",
+        "@nomicfoundation/ethereumjs-rlp": "4.0.3",
+        "@nomicfoundation/ethereumjs-statemanager": "1.0.5",
+        "@nomicfoundation/ethereumjs-trie": "5.0.5",
+        "@nomicfoundation/ethereumjs-tx": "4.1.2",
+        "@nomicfoundation/ethereumjs-util": "8.0.6",
+        "@types/async-eventemitter": "^0.2.1",
+        "async-eventemitter": "^0.2.4",
+        "debug": "^4.3.3",
+        "ethereum-cryptography": "0.1.3",
+        "functional-red-black-tree": "^1.0.1",
+        "mcl-wasm": "^0.7.1",
+        "rustbn.js": "~0.2.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@nomicfoundation/hardhat-network-helpers": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-network-helpers/-/hardhat-network-helpers-1.0.9.tgz",
+      "integrity": "sha512-OXWCv0cHpwLUO2u7bFxBna6dQtCC2Gg/aN/KtJLO7gmuuA28vgmVKYFRCDUqrbjujzgfwQ2aKyZ9Y3vSmDqS7Q==",
+      "dev": true,
+      "dependencies": {
+        "ethereumjs-util": "^7.1.4"
+      },
+      "peerDependencies": {
+        "hardhat": "^2.9.5"
+      }
+    },
+    "node_modules/@nomicfoundation/solidity-analyzer": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer/-/solidity-analyzer-0.1.1.tgz",
+      "integrity": "sha512-1LMtXj1puAxyFusBgUIy5pZk3073cNXYnXUpuNKFghHbIit/xZgbk0AokpUADbNm3gyD6bFWl3LRFh3dhVdREg==",
+      "engines": {
+        "node": ">= 12"
+      },
+      "optionalDependencies": {
+        "@nomicfoundation/solidity-analyzer-darwin-arm64": "0.1.1",
+        "@nomicfoundation/solidity-analyzer-darwin-x64": "0.1.1",
+        "@nomicfoundation/solidity-analyzer-freebsd-x64": "0.1.1",
+        "@nomicfoundation/solidity-analyzer-linux-arm64-gnu": "0.1.1",
+        "@nomicfoundation/solidity-analyzer-linux-arm64-musl": "0.1.1",
+        "@nomicfoundation/solidity-analyzer-linux-x64-gnu": "0.1.1",
+        "@nomicfoundation/solidity-analyzer-linux-x64-musl": "0.1.1",
+        "@nomicfoundation/solidity-analyzer-win32-arm64-msvc": "0.1.1",
+        "@nomicfoundation/solidity-analyzer-win32-ia32-msvc": "0.1.1",
+        "@nomicfoundation/solidity-analyzer-win32-x64-msvc": "0.1.1"
+      }
+    },
+    "node_modules/@nomicfoundation/solidity-analyzer-darwin-arm64": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-darwin-arm64/-/solidity-analyzer-darwin-arm64-0.1.1.tgz",
+      "integrity": "sha512-KcTodaQw8ivDZyF+D76FokN/HdpgGpfjc/gFCImdLUyqB6eSWVaZPazMbeAjmfhx3R0zm/NYVzxwAokFKgrc0w==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nomicfoundation/solidity-analyzer-darwin-x64": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-darwin-x64/-/solidity-analyzer-darwin-x64-0.1.1.tgz",
+      "integrity": "sha512-XhQG4BaJE6cIbjAVtzGOGbK3sn1BO9W29uhk9J8y8fZF1DYz0Doj8QDMfpMu+A6TjPDs61lbsmeYodIDnfveSA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nomicfoundation/solidity-analyzer-freebsd-x64": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-freebsd-x64/-/solidity-analyzer-freebsd-x64-0.1.1.tgz",
+      "integrity": "sha512-GHF1VKRdHW3G8CndkwdaeLkVBi5A9u2jwtlS7SLhBc8b5U/GcoL39Q+1CSO3hYqePNP+eV5YI7Zgm0ea6kMHoA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nomicfoundation/solidity-analyzer-linux-arm64-gnu": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-linux-arm64-gnu/-/solidity-analyzer-linux-arm64-gnu-0.1.1.tgz",
+      "integrity": "sha512-g4Cv2fO37ZsUENQ2vwPnZc2zRenHyAxHcyBjKcjaSmmkKrFr64yvzeNO8S3GBFCo90rfochLs99wFVGT/0owpg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nomicfoundation/solidity-analyzer-linux-arm64-musl": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-linux-arm64-musl/-/solidity-analyzer-linux-arm64-musl-0.1.1.tgz",
+      "integrity": "sha512-WJ3CE5Oek25OGE3WwzK7oaopY8xMw9Lhb0mlYuJl/maZVo+WtP36XoQTb7bW/i8aAdHW5Z+BqrHMux23pvxG3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nomicfoundation/solidity-analyzer-linux-x64-gnu": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-linux-x64-gnu/-/solidity-analyzer-linux-x64-gnu-0.1.1.tgz",
+      "integrity": "sha512-5WN7leSr5fkUBBjE4f3wKENUy9HQStu7HmWqbtknfXkkil+eNWiBV275IOlpXku7v3uLsXTOKpnnGHJYI2qsdA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nomicfoundation/solidity-analyzer-linux-x64-musl": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-linux-x64-musl/-/solidity-analyzer-linux-x64-musl-0.1.1.tgz",
+      "integrity": "sha512-KdYMkJOq0SYPQMmErv/63CwGwMm5XHenEna9X9aB8mQmhDBrYrlAOSsIPgFCUSL0hjxE3xHP65/EPXR/InD2+w==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nomicfoundation/solidity-analyzer-win32-arm64-msvc": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-win32-arm64-msvc/-/solidity-analyzer-win32-arm64-msvc-0.1.1.tgz",
+      "integrity": "sha512-VFZASBfl4qiBYwW5xeY20exWhmv6ww9sWu/krWSesv3q5hA0o1JuzmPHR4LPN6SUZj5vcqci0O6JOL8BPw+APg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nomicfoundation/solidity-analyzer-win32-ia32-msvc": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-win32-ia32-msvc/-/solidity-analyzer-win32-ia32-msvc-0.1.1.tgz",
+      "integrity": "sha512-JnFkYuyCSA70j6Si6cS1A9Gh1aHTEb8kOTBApp/c7NRTFGNMH8eaInKlyuuiIbvYFhlXW4LicqyYuWNNq9hkpQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nomicfoundation/solidity-analyzer-win32-x64-msvc": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-win32-x64-msvc/-/solidity-analyzer-win32-x64-msvc-0.1.1.tgz",
+      "integrity": "sha512-HrVJr6+WjIXGnw3Q9u6KQcbZCtk0caVWhCdFADySvRyUxJ8PnzlaP+MhwNE8oyT8OZ6ejHBRrrgjSqDCFXGirw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@nomiclabs/ethereumjs-vm": {
@@ -1769,7 +2112,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.3.tgz",
       "integrity": "sha512-/+SgoRjLq7Xlf0CWuLHq2LUZeL/w65kfzAPG5NH9pcmBhs+nunQTn4gvdwgMTIXnt9b2C/1SeL2XiysZEyIC9Q==",
-      "dev": true,
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
@@ -4517,10 +4859,13 @@
         "typechain": "^3.0.0"
       }
     },
-    "node_modules/@types/abstract-leveldown": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@types/abstract-leveldown/-/abstract-leveldown-7.2.0.tgz",
-      "integrity": "sha512-q5veSX6zjUy/DlDhR4Y4cU0k2Ar+DT2LUraP00T19WLmTO6Se1djepCCaqU6nQrwcJ5Hyo/CWqxTzrrFg8eqbQ=="
+    "node_modules/@types/async-eventemitter": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@types/async-eventemitter/-/async-eventemitter-0.2.4.tgz",
+      "integrity": "sha512-2Bq61VD01kgLf1XkK2xPtoBcu7fgn/km5JyEX9v0BlG5VQBzA+BlF9umFk+8gR8S4+eK7MgDY2oyVZCu6ar3Jw==",
+      "dependencies": {
+        "@types/events": "*"
+      }
     },
     "node_modules/@types/bn.js": {
       "version": "5.1.2",
@@ -4556,6 +4901,11 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/events": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.3.tgz",
+      "integrity": "sha512-trOc4AAUThEz9hapPtSd7wf5tiQKvTtu5b371UxXdTuqzIh0ArcRspRP0i0Viu+LXstIQ1z96t1nsPxT9ol01g=="
+    },
     "node_modules/@types/form-data": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-0.0.33.tgz",
@@ -4586,21 +4936,6 @@
       "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
       "dev": true,
       "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/level-errors": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/level-errors/-/level-errors-3.0.0.tgz",
-      "integrity": "sha512-/lMtoq/Cf/2DVOm6zE6ORyOM+3ZVm/BvzEZVxUhf6bgh8ZHglXlBqxbxSlJeVp8FCbD3IVvk/VbsaNmDjrQvqQ=="
-    },
-    "node_modules/@types/levelup": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/@types/levelup/-/levelup-4.3.3.tgz",
-      "integrity": "sha512-K+OTIjJcZHVlZQN1HmU64VtrC0jC3dXWQozuEIR9zVvltIk90zaGPM2AgT+fIkChpzHhFE3YnvFLCbLtzAmexA==",
-      "dependencies": {
-        "@types/abstract-leveldown": "*",
-        "@types/level-errors": "*",
         "@types/node": "*"
       }
     },
@@ -4748,19 +5083,44 @@
       "integrity": "sha512-JMJ5soJWP18htbbxJjG7bG6yuI6pRhgJ0scHHTfkUjf6wjP912xZWvM+A4sJK3gqd9E8fcPbDnOefbA9Th/FIQ==",
       "dev": true
     },
-    "node_modules/abstract-leveldown": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.3.0.tgz",
-      "integrity": "sha512-TU5nlYgta8YrBMNpc9FwQzRbiXsj49gsALsXadbGHt9CROPzX5fB0rWDR5mtdpOOKa5XqRFpbj1QroPAoPzVjQ==",
+    "node_modules/abstract-level": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/abstract-level/-/abstract-level-1.0.4.tgz",
+      "integrity": "sha512-eUP/6pbXBkMbXFdx4IH2fVgvB7M0JvR7/lIL33zcs0IBcwjdzSSl31TOJsaCzmKSSDF9h8QYSOJux4Nd4YJqFg==",
       "dependencies": {
-        "buffer": "^5.5.0",
-        "immediate": "^3.2.3",
-        "level-concat-iterator": "~2.0.0",
-        "level-supports": "~1.0.0",
-        "xtend": "~4.0.0"
+        "buffer": "^6.0.3",
+        "catering": "^2.1.0",
+        "is-buffer": "^2.0.5",
+        "level-supports": "^4.0.0",
+        "level-transcoder": "^1.0.1",
+        "module-error": "^1.0.1",
+        "queue-microtask": "^1.2.3"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=12"
+      }
+    },
+    "node_modules/abstract-level/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/accepts": {
@@ -4807,6 +5167,18 @@
       },
       "engines": {
         "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/aggregate-error": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+      "dependencies": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/ajv": {
@@ -5101,6 +5473,14 @@
         "url": "https://opencollective.com/bigjs"
       }
     },
+    "node_modules/bigint-crypto-utils": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/bigint-crypto-utils/-/bigint-crypto-utils-3.3.0.tgz",
+      "integrity": "sha512-jOTSb+drvEDxEq6OuUybOAv/xxoh3cuYRUIPyu8sSHQNKM303UQ2R1DAo45o1AkcIXw6fzbaFI1+xGGdaXs2lg==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/bignumber.js": {
       "version": "9.0.2",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.2.tgz",
@@ -5218,6 +5598,17 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
+    },
+    "node_modules/browser-level": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/browser-level/-/browser-level-1.0.1.tgz",
+      "integrity": "sha512-XECYKJ+Dbzw0lbydyQuJzwNXtOpbMSq737qxJN11sIRTErOMShvDpbzTlgju7orJKvx4epULolZAuJGLzCmWRQ==",
+      "dependencies": {
+        "abstract-level": "^1.0.2",
+        "catering": "^2.1.1",
+        "module-error": "^1.0.2",
+        "run-parallel-limit": "^1.1.0"
+      }
     },
     "node_modules/browser-stdout": {
       "version": "1.3.1",
@@ -5470,6 +5861,14 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+    },
+    "node_modules/catering": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/catering/-/catering-2.1.1.tgz",
+      "integrity": "sha512-K7Qy8O9p76sL3/3m7/zLKbRkyOlSZAgzEaLhyj2mXS8PsCud2Eo4hAb8aLtZqHh0QGqLcb9dlJSu6lHRVENm1w==",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/cbor": {
       "version": "5.2.0",
@@ -5733,6 +6132,30 @@
       "resolved": "https://registry.npmjs.org/class-is/-/class-is-1.1.0.tgz",
       "integrity": "sha512-rhjH9AG1fvabIDoGRVH587413LPjTZgmDF9fOFCbFJQV4yuocX1mHxxvXI4g3cGwbVY9wAYIoKlg1N79frJKQw==",
       "dev": true
+    },
+    "node_modules/classic-level": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/classic-level/-/classic-level-1.4.1.tgz",
+      "integrity": "sha512-qGx/KJl3bvtOHrGau2WklEZuXhS3zme+jf+fsu6Ej7W7IP/C49v7KNlWIsT1jZu0YnfzSIYDGcEWpCa1wKGWXQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "abstract-level": "^1.0.2",
+        "catering": "^2.1.0",
+        "module-error": "^1.0.1",
+        "napi-macros": "^2.2.2",
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/clean-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/cli-table3": {
       "version": "0.5.1",
@@ -6189,9 +6612,9 @@
       "dev": true
     },
     "node_modules/debug": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -6273,33 +6696,6 @@
       "dev": true,
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/deferred-leveldown": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-5.3.0.tgz",
-      "integrity": "sha512-a59VOT+oDy7vtAbLRCZwWgxu2BaCfd5Hk7wxJd48ei7I+nsg8Orlb9CLG0PMZienk9BSUKgeAqkO2+Lw+1+Ukw==",
-      "dependencies": {
-        "abstract-leveldown": "~6.2.1",
-        "inherits": "^2.0.3"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/deferred-leveldown/node_modules/abstract-leveldown": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.2.3.tgz",
-      "integrity": "sha512-BsLm5vFMRUrrLeCcRc+G0t2qOaTzpoJQLOubq2XM72eNpjF5UdU5o/5NvlNhx95XHcAvcl8OMXr4mlg/fRgUXQ==",
-      "dependencies": {
-        "buffer": "^5.5.0",
-        "immediate": "^3.2.3",
-        "level-concat-iterator": "~2.0.0",
-        "level-supports": "~1.0.0",
-        "xtend": "~4.0.0"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/define-properties": {
@@ -6552,20 +6948,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/encoding-down": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/encoding-down/-/encoding-down-6.3.0.tgz",
-      "integrity": "sha512-QKrV0iKR6MZVJV08QY0wp1e7vF6QbhnbQhb07bwpEyuz4uZiZgPlEGdkCROuFkUwdxlFaiPIhjyarH1ee/3vhw==",
-      "dependencies": {
-        "abstract-leveldown": "^6.2.1",
-        "inherits": "^2.0.3",
-        "level-codec": "^9.0.0",
-        "level-errors": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/end-of-stream": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
@@ -6732,6 +7114,14 @@
       "dependencies": {
         "d": "^1.0.1",
         "ext": "^1.1.2"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
+      "integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/escape-html": {
@@ -7012,32 +7402,6 @@
         "async-limiter": "~1.0.0",
         "safe-buffer": "~5.1.0",
         "ultron": "~1.1.0"
-      }
-    },
-    "node_modules/eth-sig-util": {
-      "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-2.5.4.tgz",
-      "integrity": "sha512-aCMBwp8q/4wrW4QLsF/HYBOSA7TpLKmkVwP3pYQNkEEseW2Rr8Z5Uxc9/h6HX+OG3tuHo+2bINVSihIeBfym6A==",
-      "deprecated": "Deprecated in favor of '@metamask/eth-sig-util'",
-      "dependencies": {
-        "ethereumjs-abi": "0.6.8",
-        "ethereumjs-util": "^5.1.1",
-        "tweetnacl": "^1.0.3",
-        "tweetnacl-util": "^0.15.0"
-      }
-    },
-    "node_modules/eth-sig-util/node_modules/ethereumjs-util": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
-      "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
-      "dependencies": {
-        "bn.js": "^4.11.0",
-        "create-hash": "^1.1.2",
-        "elliptic": "^6.5.2",
-        "ethereum-cryptography": "^0.1.3",
-        "ethjs-util": "^0.1.3",
-        "rlp": "^2.0.0",
-        "safe-buffer": "^5.1.1"
       }
     },
     "node_modules/ethashjs": {
@@ -17675,22 +18039,29 @@
       }
     },
     "node_modules/hardhat": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/hardhat/-/hardhat-2.8.2.tgz",
-      "integrity": "sha512-cBUqzZGOi+lwKHArWl5Be7zeFIwlu1IUXOna6k5XhORZ8hAWDVbAJBVfxgmjkcX5GffIf0C5g841zRxo36sQ5g==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/hardhat/-/hardhat-2.13.0.tgz",
+      "integrity": "sha512-ZlzBOLML1QGlm6JWyVAG8lVTEAoOaVm1in/RU2zoGAnYEoD1Rp4T+ZMvrLNhHaaeS9hfjJ1gJUBfiDr4cx+htQ==",
       "dependencies": {
-        "@ethereumjs/block": "^3.6.0",
-        "@ethereumjs/blockchain": "^5.5.0",
-        "@ethereumjs/common": "^2.6.0",
-        "@ethereumjs/tx": "^3.4.0",
-        "@ethereumjs/vm": "^5.6.0",
         "@ethersproject/abi": "^5.1.2",
+        "@metamask/eth-sig-util": "^4.0.0",
+        "@nomicfoundation/ethereumjs-block": "^4.0.0",
+        "@nomicfoundation/ethereumjs-blockchain": "^6.0.0",
+        "@nomicfoundation/ethereumjs-common": "^3.0.0",
+        "@nomicfoundation/ethereumjs-evm": "^1.0.0",
+        "@nomicfoundation/ethereumjs-rlp": "^4.0.0",
+        "@nomicfoundation/ethereumjs-statemanager": "^1.0.0",
+        "@nomicfoundation/ethereumjs-trie": "^5.0.0",
+        "@nomicfoundation/ethereumjs-tx": "^4.0.0",
+        "@nomicfoundation/ethereumjs-util": "^8.0.0",
+        "@nomicfoundation/ethereumjs-vm": "^6.0.0",
+        "@nomicfoundation/solidity-analyzer": "^0.1.0",
         "@sentry/node": "^5.18.1",
-        "@solidity-parser/parser": "^0.14.0",
         "@types/bn.js": "^5.1.0",
         "@types/lru-cache": "^5.1.0",
         "abort-controller": "^3.0.0",
         "adm-zip": "^0.4.16",
+        "aggregate-error": "^3.0.0",
         "ansi-escapes": "^4.3.0",
         "chalk": "^2.4.2",
         "chokidar": "^3.4.0",
@@ -17698,40 +18069,48 @@
         "debug": "^4.1.1",
         "enquirer": "^2.3.0",
         "env-paths": "^2.2.0",
-        "eth-sig-util": "^2.5.2",
-        "ethereum-cryptography": "^0.1.2",
+        "ethereum-cryptography": "^1.0.3",
         "ethereumjs-abi": "^0.6.8",
-        "ethereumjs-util": "^7.1.3",
         "find-up": "^2.1.0",
         "fp-ts": "1.19.3",
         "fs-extra": "^7.0.1",
-        "glob": "^7.1.3",
-        "https-proxy-agent": "^5.0.0",
+        "glob": "7.2.0",
         "immutable": "^4.0.0-rc.12",
         "io-ts": "1.10.4",
+        "keccak": "^3.0.2",
         "lodash": "^4.17.11",
-        "merkle-patricia-tree": "^4.2.2",
         "mnemonist": "^0.38.0",
-        "mocha": "^7.2.0",
-        "node-fetch": "^2.6.0",
+        "mocha": "^10.0.0",
+        "p-map": "^4.0.0",
         "qs": "^6.7.0",
         "raw-body": "^2.4.1",
         "resolve": "1.17.0",
         "semver": "^6.3.0",
-        "slash": "^3.0.0",
         "solc": "0.7.3",
         "source-map-support": "^0.5.13",
         "stacktrace-parser": "^0.1.10",
-        "true-case-path": "^2.2.1",
         "tsort": "0.0.1",
+        "undici": "^5.14.0",
         "uuid": "^8.3.2",
         "ws": "^7.4.6"
       },
       "bin": {
-        "hardhat": "internal/cli/cli.js"
+        "hardhat": "internal/cli/bootstrap.js"
       },
       "engines": {
-        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "ts-node": "*",
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "ts-node": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/hardhat-gas-reporter": {
@@ -18516,6 +18895,80 @@
         "@ethersproject/wordlists": "5.7.0"
       }
     },
+    "node_modules/hardhat/node_modules/@noble/hashes": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.2.0.tgz",
+      "integrity": "sha512-FZfhjEDbT5GRswV3C6uvLPHMiVD6lQBmpoX5+eSiPaMTXte/IKqI5dykDxzZB/WBeK/CDuQRBWarPdi3FNY2zQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ]
+    },
+    "node_modules/hardhat/node_modules/@scure/bip32": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.1.5.tgz",
+      "integrity": "sha512-XyNh1rB0SkEqd3tXcXMi+Xe1fvg+kUIcoRIEujP1Jgv7DqW2r9lg3Ah0NkFaCs9sTkQAQA8kw7xiRXzENi9Rtw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "dependencies": {
+        "@noble/hashes": "~1.2.0",
+        "@noble/secp256k1": "~1.7.0",
+        "@scure/base": "~1.1.0"
+      }
+    },
+    "node_modules/hardhat/node_modules/@scure/bip39": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.1.1.tgz",
+      "integrity": "sha512-t+wDck2rVkh65Hmv280fYdVdY25J9YeEUIgn2LG1WM6gxFkGzcksoDiUkWVpVp3Oex9xGC68JU2dSbUfwZ2jPg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "dependencies": {
+        "@noble/hashes": "~1.2.0",
+        "@scure/base": "~1.1.0"
+      }
+    },
+    "node_modules/hardhat/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/hardhat/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+    },
+    "node_modules/hardhat/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/hardhat/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/hardhat/node_modules/chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -18529,12 +18982,329 @@
         "node": ">=4"
       }
     },
+    "node_modules/hardhat/node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/hardhat/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/hardhat/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/hardhat/node_modules/decamelize": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+      "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/hardhat/node_modules/diff": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+      "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/hardhat/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "node_modules/hardhat/node_modules/ethereum-cryptography": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-1.2.0.tgz",
+      "integrity": "sha512-6yFQC9b5ug6/17CQpCyE3k9eKBMdhyVjzUy1WkiuY/E4vj/SXDBbCw8QEIaXqf0Mf2SnY6RmpDcwlUmBSS0EJw==",
+      "dependencies": {
+        "@noble/hashes": "1.2.0",
+        "@noble/secp256k1": "1.7.1",
+        "@scure/bip32": "1.1.5",
+        "@scure/bip39": "1.1.1"
+      }
+    },
+    "node_modules/hardhat/node_modules/flat": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+      "bin": {
+        "flat": "cli.js"
+      }
+    },
+    "node_modules/hardhat/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/hardhat/node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/hardhat/node_modules/jsonfile": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/hardhat/node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/hardhat/node_modules/log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/hardhat/node_modules/log-symbols/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/hardhat/node_modules/log-symbols/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/hardhat/node_modules/log-symbols/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/hardhat/node_modules/log-symbols/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/hardhat/node_modules/minimatch": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
+      "integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/hardhat/node_modules/mocha": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.3.0.tgz",
+      "integrity": "sha512-uF2XJs+7xSLsrmIvn37i/wnc91nw7XjOQB8ccyx5aEgdnohr7n+rEiZP23WkCYHjilR6+EboEnbq/ZQDz4LSbg==",
+      "dependencies": {
+        "ansi-colors": "4.1.1",
+        "browser-stdout": "1.3.1",
+        "chokidar": "3.5.3",
+        "debug": "4.3.4",
+        "diff": "5.0.0",
+        "escape-string-regexp": "4.0.0",
+        "find-up": "5.0.0",
+        "glob": "8.1.0",
+        "he": "1.2.0",
+        "js-yaml": "4.1.0",
+        "log-symbols": "4.1.0",
+        "minimatch": "5.0.1",
+        "ms": "2.1.3",
+        "serialize-javascript": "6.0.0",
+        "strip-json-comments": "3.1.1",
+        "supports-color": "8.1.1",
+        "workerpool": "6.2.1",
+        "yargs": "16.2.0",
+        "yargs-parser": "20.2.4",
+        "yargs-unparser": "2.0.0"
+      },
+      "bin": {
+        "_mocha": "bin/_mocha",
+        "mocha": "bin/mocha.js"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/hardhat/node_modules/mocha/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/hardhat/node_modules/mocha/node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/hardhat/node_modules/mocha/node_modules/glob": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/hardhat/node_modules/mocha/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/hardhat/node_modules/mocha/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/hardhat/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node_modules/hardhat/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/hardhat/node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/hardhat/node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/hardhat/node_modules/solc": {
@@ -18579,6 +19349,41 @@
         "semver": "bin/semver"
       }
     },
+    "node_modules/hardhat/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/hardhat/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/hardhat/node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/hardhat/node_modules/supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -18588,6 +19393,83 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/hardhat/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/hardhat/node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/hardhat/node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/hardhat/node_modules/yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/hardhat/node_modules/yargs-parser": {
+      "version": "20.2.4",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
+      "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/hardhat/node_modules/yargs-unparser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+      "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+      "dependencies": {
+        "camelcase": "^6.0.0",
+        "decamelize": "^4.0.0",
+        "flat": "^5.0.2",
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/has": {
@@ -18897,6 +19779,14 @@
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.0.0.tgz",
       "integrity": "sha512-zIE9hX70qew5qTUjSS7wi1iwj/l7+m54KWU247nhM3v806UdGj1yDndXj+IOYxxtW9zyLI+xqFNZjTuDaLUqFw=="
     },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -19197,6 +20087,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-regex": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
@@ -19267,6 +20165,17 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/is-upper-case": {
       "version": "1.1.2",
@@ -19462,6 +20371,23 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/level": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/level/-/level-8.0.1.tgz",
+      "integrity": "sha512-oPBGkheysuw7DmzFQYyFe8NAia5jFLAgEnkgWnK3OXAuJr8qFT+xBQIwokAZPME2bhPFzS8hlYcL16m8UZrtwQ==",
+      "dependencies": {
+        "abstract-level": "^1.0.4",
+        "browser-level": "^1.0.1",
+        "classic-level": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/level"
+      }
+    },
     "node_modules/level-codec": {
       "version": "9.0.2",
       "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-9.0.2.tgz",
@@ -19469,14 +20395,6 @@
       "dependencies": {
         "buffer": "^5.6.0"
       },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/level-concat-iterator": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/level-concat-iterator/-/level-concat-iterator-2.0.1.tgz",
-      "integrity": "sha512-OTKKOqeav2QWcERMJR7IS9CUo1sHnke2C0gkSmcR7QuEtFNLLzHQAvnMw8ykvEcv0Qtkg0p7FOwP1v9e5Smdcw==",
       "engines": {
         "node": ">=6"
       }
@@ -19492,80 +20410,47 @@
         "node": ">=6"
       }
     },
-    "node_modules/level-iterator-stream": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-4.0.2.tgz",
-      "integrity": "sha512-ZSthfEqzGSOMWoUGhTXdX9jv26d32XJuHz/5YnuHZzH6wldfWMOVwI9TBtKcya4BKTyTt3XVA0A3cF3q5CY30Q==",
-      "dependencies": {
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0",
-        "xtend": "^4.0.2"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/level-mem": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/level-mem/-/level-mem-5.0.1.tgz",
-      "integrity": "sha512-qd+qUJHXsGSFoHTziptAKXoLX87QjR7v2KMbqncDXPxQuCdsQlzmyX+gwrEHhlzn08vkf8TyipYyMmiC6Gobzg==",
-      "dependencies": {
-        "level-packager": "^5.0.3",
-        "memdown": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/level-packager": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/level-packager/-/level-packager-5.1.1.tgz",
-      "integrity": "sha512-HMwMaQPlTC1IlcwT3+swhqf/NUO+ZhXVz6TY1zZIIZlIR0YSn8GtAAWmIvKjNY16ZkEg/JcpAuQskxsXqC0yOQ==",
-      "dependencies": {
-        "encoding-down": "^6.3.0",
-        "levelup": "^4.3.2"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/level-supports": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-4.0.1.tgz",
+      "integrity": "sha512-PbXpve8rKeNcZ9C1mUicC9auIYFyGpkV9/i6g76tLgANwWhtG2v7I4xNBUlkn3lE2/dZF3Pi0ygYGtLc4RXXdA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/level-transcoder": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-1.0.1.tgz",
-      "integrity": "sha512-rXM7GYnW8gsl1vedTJIbzOrRv85c/2uCMpiiCzO2fndd06U/kUXEEU9evYn4zFggBOg36IsBW8LzqIpETwwQzg==",
+      "resolved": "https://registry.npmjs.org/level-transcoder/-/level-transcoder-1.0.1.tgz",
+      "integrity": "sha512-t7bFwFtsQeD8cl8NIoQ2iwxA0CL/9IFw7/9gAjOonH0PWTTiRfY7Hq+Ejbsxh86tXobDQ6IOiddjNYIfOBs06w==",
       "dependencies": {
-        "xtend": "^4.0.2"
+        "buffer": "^6.0.3",
+        "module-error": "^1.0.1"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=12"
       }
     },
-    "node_modules/level-ws": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/level-ws/-/level-ws-2.0.0.tgz",
-      "integrity": "sha512-1iv7VXx0G9ec1isqQZ7y5LmoZo/ewAsyDHNA8EFDW5hqH2Kqovm33nSFkSdnLLAK+I5FlT+lo5Cw9itGe+CpQA==",
+    "node_modules/level-transcoder/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
       "dependencies": {
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.0",
-        "xtend": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/levelup": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/levelup/-/levelup-4.4.0.tgz",
-      "integrity": "sha512-94++VFO3qN95cM/d6eBXvd894oJE0w3cInq9USsyQzzoJxmiYzPAocNcuGCPGGjoXqDVJcr3C1jzt1TSjyaiLQ==",
-      "dependencies": {
-        "deferred-leveldown": "~5.3.0",
-        "level-errors": "~2.0.0",
-        "level-iterator-stream": "~4.0.0",
-        "level-supports": "~1.0.0",
-        "xtend": "~4.0.0"
-      },
-      "engines": {
-        "node": ">=6"
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/levn": {
@@ -19763,41 +20648,18 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/memdown": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/memdown/-/memdown-5.1.0.tgz",
-      "integrity": "sha512-B3J+UizMRAlEArDjWHTMmadet+UKwHd3UjMgGBkZcKAxAYVPS9o0Yeiha4qvz7iGiL2Sb3igUft6p7nbFWctpw==",
+    "node_modules/memory-level": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/memory-level/-/memory-level-1.0.0.tgz",
+      "integrity": "sha512-UXzwewuWeHBz5krr7EvehKcmLFNoXxGcvuYhC41tRnkrTbJohtS7kVn9akmgirtRygg+f7Yjsfi8Uu5SGSQ4Og==",
       "dependencies": {
-        "abstract-leveldown": "~6.2.1",
-        "functional-red-black-tree": "~1.0.1",
-        "immediate": "~3.2.3",
-        "inherits": "~2.0.1",
-        "ltgt": "~2.2.0",
-        "safe-buffer": "~5.2.0"
+        "abstract-level": "^1.0.0",
+        "functional-red-black-tree": "^1.0.1",
+        "module-error": "^1.0.1"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=12"
       }
-    },
-    "node_modules/memdown/node_modules/abstract-leveldown": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.2.3.tgz",
-      "integrity": "sha512-BsLm5vFMRUrrLeCcRc+G0t2qOaTzpoJQLOubq2XM72eNpjF5UdU5o/5NvlNhx95XHcAvcl8OMXr4mlg/fRgUXQ==",
-      "dependencies": {
-        "buffer": "^5.5.0",
-        "immediate": "^3.2.3",
-        "level-concat-iterator": "~2.0.0",
-        "level-supports": "~1.0.0",
-        "xtend": "~4.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/memdown/node_modules/immediate": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.2.3.tgz",
-      "integrity": "sha1-0UD6j2FGWb1lQSMwl92qwlzdmRw="
     },
     "node_modules/memorystream": {
       "version": "0.3.1",
@@ -19820,19 +20682,6 @@
       "dev": true,
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/merkle-patricia-tree": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/merkle-patricia-tree/-/merkle-patricia-tree-4.2.3.tgz",
-      "integrity": "sha512-S4xevdXl5KvdBGgUxhQcxoep0onqXiIhzfwZp4M78kIuJH3Pu9o9IUgqhzSFOR2ykLO6t265026Xb6PY0q2UFQ==",
-      "dependencies": {
-        "@types/levelup": "^4.3.0",
-        "ethereumjs-util": "^7.1.4",
-        "level-mem": "^5.0.1",
-        "level-ws": "^2.0.0",
-        "readable-stream": "^3.6.0",
-        "semaphore-async-await": "^1.5.1"
       }
     },
     "node_modules/methods": {
@@ -20199,6 +21048,14 @@
       "integrity": "sha512-qYvlv/exQ4+svI3UOvPUpLDF0OMX5euvUH0Ny4N5QyRyhNdgAgUrVH3iUINSzEPLvx0kbo/Bp28GJKIqvE7URw==",
       "dev": true
     },
+    "node_modules/module-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/module-error/-/module-error-1.0.2.tgz",
+      "integrity": "sha512-0yuvsqSCv8LbaOKhnsQ/T5JhyFlCYLPXK3U2sgV10zoKQwzs/MyfuQUOZQ1V/6OCOJsK/TRgNVrPuPDqtdMFtA==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -20263,6 +21120,11 @@
       "resolved": "https://registry.npmjs.org/nano-json-stream-parser/-/nano-json-stream-parser-0.1.2.tgz",
       "integrity": "sha512-9MqxMH/BSJC7dnLsEMPyfN5Dvoo49IsPFYMcHw3Bcfc2kN0lpHRBSzlMSVx4HGyJ7s9B31CyBTVehWJoQ8Ctew==",
       "dev": true
+    },
+    "node_modules/napi-macros": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/napi-macros/-/napi-macros-2.2.2.tgz",
+      "integrity": "sha512-hmEVtAGYzVQpCKdbQea4skABsdXW4RUh5t5mJ2zzqowJS2OyXZTU1KhDVFhx+NlWZ4ap9mqR9TcDO3LTTttd+g=="
     },
     "node_modules/negotiator": {
       "version": "0.6.3",
@@ -20640,6 +21502,20 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/p-map": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+      "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+      "dependencies": {
+        "aggregate-error": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-try": {
@@ -21128,7 +22004,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -21574,6 +22449,28 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/run-parallel-limit": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/run-parallel-limit/-/run-parallel-limit-1.1.0.tgz",
+      "integrity": "sha512-jJA7irRNM91jaKc3Hcl1npHsFLOXOoTkPCUL1JEa1R82O2miplXXRaGdjW/KM/98YQWDhJLiSs793CnXfblJUw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
     "node_modules/rustbn.js": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/rustbn.js/-/rustbn.js-0.2.0.tgz",
@@ -21730,14 +22627,6 @@
         "node": ">=0.8.0"
       }
     },
-    "node_modules/semaphore-async-await": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/semaphore-async-await/-/semaphore-async-await-1.5.1.tgz",
-      "integrity": "sha1-hXvvXjZEYBykuVcLh+nfXKEpdPo=",
-      "engines": {
-        "node": ">=4.1"
-      }
-    },
     "node_modules/semver": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -21799,6 +22688,14 @@
       "dependencies": {
         "no-case": "^2.2.0",
         "upper-case-first": "^1.1.2"
+      }
+    },
+    "node_modules/serialize-javascript": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
+      "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
+      "dependencies": {
+        "randombytes": "^2.1.0"
       }
     },
     "node_modules/serve-static": {
@@ -22002,6 +22899,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -22735,11 +23633,6 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
     },
-    "node_modules/true-case-path": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/true-case-path/-/true-case-path-2.2.1.tgz",
-      "integrity": "sha512-0z3j8R7MCjy10kc/g+qg7Ln3alJTodw9aDuVWZa3uiWqfuBMKeAeP2ocWcxoyM3D73yz3Jt/Pu4qPr4wHSdB/Q=="
-    },
     "node_modules/ts-essentials": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-1.0.4.tgz",
@@ -22919,7 +23812,7 @@
       "version": "4.5.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
       "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
-      "dev": true,
+      "devOptional": true,
       "peer": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -22966,6 +23859,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici": {
+      "version": "5.28.3",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.3.tgz",
+      "integrity": "sha512-3ItfzbrhDlINjaP0duwnNsKpDQk3acHI3gVJ1z4fmwMK31k5G9OVIAMLSIaP6w4FaGkaAkN6zaQO9LUvZ1t7VA==",
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
       }
     },
     "node_modules/universalify": {
@@ -26004,6 +26908,11 @@
       "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
       "dev": true
     },
+    "node_modules/workerpool": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.1.tgz",
+      "integrity": "sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw=="
+    },
     "node_modules/wrap-ansi": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
@@ -26279,6 +27188,17 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   },
@@ -26613,66 +27533,14 @@
         "postinstall-postinstall": "^2.1.0"
       }
     },
-    "@ethereumjs/block": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/@ethereumjs/block/-/block-3.6.1.tgz",
-      "integrity": "sha512-o5d/zpGl4SdVfdTfrsq9ZgYMXddc0ucKMiFW5OphBCX+ep4xzYnSjboFcZXT2V/tcSBr84VrKWWp21CGVb3DGw==",
-      "requires": {
-        "@ethereumjs/common": "^2.6.1",
-        "@ethereumjs/tx": "^3.5.0",
-        "ethereumjs-util": "^7.1.4",
-        "merkle-patricia-tree": "^4.2.3"
-      }
-    },
-    "@ethereumjs/blockchain": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/@ethereumjs/blockchain/-/blockchain-5.5.1.tgz",
-      "integrity": "sha512-JS2jeKxl3tlaa5oXrZ8mGoVBCz6YqsGG350XVNtHAtNZXKk7pU3rH4xzF2ru42fksMMqzFLzKh9l4EQzmNWDqA==",
-      "requires": {
-        "@ethereumjs/block": "^3.6.0",
-        "@ethereumjs/common": "^2.6.0",
-        "@ethereumjs/ethash": "^1.1.0",
-        "debug": "^2.2.0",
-        "ethereumjs-util": "^7.1.3",
-        "level-mem": "^5.0.1",
-        "lru-cache": "^5.1.1",
-        "semaphore-async-await": "^1.5.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        }
-      }
-    },
     "@ethereumjs/common": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/@ethereumjs/common/-/common-2.6.1.tgz",
       "integrity": "sha512-eUe5RsYiOnazszPsgQOdaetCwgVquiiQHBpB59xNABOrBPNh/ZdTJz+uhHGzKvPm6Dr91ViBGYZcdclTgtki0g==",
+      "dev": true,
       "requires": {
         "crc-32": "^1.2.0",
         "ethereumjs-util": "^7.1.4"
-      }
-    },
-    "@ethereumjs/ethash": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@ethereumjs/ethash/-/ethash-1.1.0.tgz",
-      "integrity": "sha512-/U7UOKW6BzpA+Vt+kISAoeDie1vAvY4Zy2KF5JJb+So7+1yKmJeJEHOGSnQIj330e9Zyl3L5Nae6VZyh2TJnAA==",
-      "requires": {
-        "@ethereumjs/block": "^3.5.0",
-        "@types/levelup": "^4.3.0",
-        "buffer-xor": "^2.0.1",
-        "ethereumjs-util": "^7.1.1",
-        "miller-rabin": "^4.0.0"
       }
     },
     "@ethereumjs/rlp": {
@@ -26685,6 +27553,7 @@
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/@ethereumjs/tx/-/tx-3.5.0.tgz",
       "integrity": "sha512-/+ZNbnJhQhXC83Xuvy6I9k4jT5sXiV0tMR9C+AzSSpcCV64+NB8dTE1m3x98RYMqb8+TLYWA+HML4F5lfXTlJw==",
+      "dev": true,
       "requires": {
         "@ethereumjs/common": "^2.6.1",
         "ethereumjs-util": "^7.1.4"
@@ -26713,25 +27582,6 @@
             "@scure/bip39": "1.2.1"
           }
         }
-      }
-    },
-    "@ethereumjs/vm": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethereumjs/vm/-/vm-5.7.0.tgz",
-      "integrity": "sha512-1ruJ6nmWYsh42I1cseIuzgCSU1MH8Bh3FSJnSNAYoS1HVmr87mB6FyIZa/OvO3W0hKYD6+/t5OsyKrq0v43fAQ==",
-      "requires": {
-        "@ethereumjs/block": "^3.6.0",
-        "@ethereumjs/blockchain": "^5.5.1",
-        "@ethereumjs/common": "^2.6.1",
-        "@ethereumjs/tx": "^3.5.0",
-        "async-eventemitter": "^0.2.4",
-        "core-js-pure": "^3.0.1",
-        "debug": "^4.3.3",
-        "ethereumjs-util": "^7.1.4",
-        "functional-red-black-tree": "^1.0.1",
-        "mcl-wasm": "^0.7.1",
-        "merkle-patricia-tree": "^4.2.3",
-        "rustbn.js": "~0.2.0"
       }
     },
     "@ethersproject/abi": {
@@ -27103,6 +27953,47 @@
         "@ethersproject/strings": "^5.5.0"
       }
     },
+    "@fastify/busboy": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.0.tgz",
+      "integrity": "sha512-+KpH+QxZU7O4675t3mnkQKcZZg56u+K/Ct2K+N2AZYNVK8kyeo/bI18tI8aPm3tvNNRyTWfj6s5tnGNlcbQRsA=="
+    },
+    "@metamask/eth-sig-util": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@metamask/eth-sig-util/-/eth-sig-util-4.0.1.tgz",
+      "integrity": "sha512-tghyZKLHZjcdlDqCA3gNZmLeR0XvOE9U1qoQO9ohyAZT6Pya+H9vkBPcsyXytmYLNgVoin7CKCmweo/R43V+tQ==",
+      "requires": {
+        "ethereumjs-abi": "^0.6.8",
+        "ethereumjs-util": "^6.2.1",
+        "ethjs-util": "^0.1.6",
+        "tweetnacl": "^1.0.3",
+        "tweetnacl-util": "^0.15.1"
+      },
+      "dependencies": {
+        "@types/bn.js": {
+          "version": "4.11.6",
+          "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
+          "integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
+          "requires": {
+            "@types/node": "*"
+          }
+        },
+        "ethereumjs-util": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
+          "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
+          "requires": {
+            "@types/bn.js": "^4.11.3",
+            "bn.js": "^4.11.0",
+            "create-hash": "^1.1.2",
+            "elliptic": "^6.5.2",
+            "ethereum-cryptography": "^0.1.3",
+            "ethjs-util": "0.1.6",
+            "rlp": "^2.2.3"
+          }
+        }
+      }
+    },
     "@noble/curves": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.1.0.tgz",
@@ -27117,6 +28008,11 @@
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.1.tgz",
       "integrity": "sha512-EbqwksQwz9xDRGfDST86whPBgM65E0OH/pCgqW0GBVzO22bNE+NuIbeTb714+IfSjU3aRk47EUvXIb5bTsenKA==",
       "dev": true
+    },
+    "@noble/secp256k1": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.1.tgz",
+      "integrity": "sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -27143,6 +28039,234 @@
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
       }
+    },
+    "@nomicfoundation/ethereumjs-block": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-block/-/ethereumjs-block-4.2.2.tgz",
+      "integrity": "sha512-atjpt4gc6ZGZUPHBAQaUJsm1l/VCo7FmyQ780tMGO8QStjLdhz09dXynmhwVTy5YbRr0FOh/uX3QaEM0yIB2Zg==",
+      "requires": {
+        "@nomicfoundation/ethereumjs-common": "3.1.2",
+        "@nomicfoundation/ethereumjs-rlp": "4.0.3",
+        "@nomicfoundation/ethereumjs-trie": "5.0.5",
+        "@nomicfoundation/ethereumjs-tx": "4.1.2",
+        "@nomicfoundation/ethereumjs-util": "8.0.6",
+        "ethereum-cryptography": "0.1.3"
+      }
+    },
+    "@nomicfoundation/ethereumjs-blockchain": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-blockchain/-/ethereumjs-blockchain-6.2.2.tgz",
+      "integrity": "sha512-6AIB2MoTEPZJLl6IRKcbd8mUmaBAQ/NMe3O7OsAOIiDjMNPPH5KaUQiLfbVlegT4wKIg/GOsFH7XlH2KDVoJNg==",
+      "requires": {
+        "@nomicfoundation/ethereumjs-block": "4.2.2",
+        "@nomicfoundation/ethereumjs-common": "3.1.2",
+        "@nomicfoundation/ethereumjs-ethash": "2.0.5",
+        "@nomicfoundation/ethereumjs-rlp": "4.0.3",
+        "@nomicfoundation/ethereumjs-trie": "5.0.5",
+        "@nomicfoundation/ethereumjs-util": "8.0.6",
+        "abstract-level": "^1.0.3",
+        "debug": "^4.3.3",
+        "ethereum-cryptography": "0.1.3",
+        "level": "^8.0.0",
+        "lru-cache": "^5.1.1",
+        "memory-level": "^1.0.0"
+      }
+    },
+    "@nomicfoundation/ethereumjs-common": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-common/-/ethereumjs-common-3.1.2.tgz",
+      "integrity": "sha512-JAEBpIua62dyObHM9KI2b4wHZcRQYYge9gxiygTWa3lNCr2zo+K0TbypDpgiNij5MCGNWP1eboNfNfx1a3vkvA==",
+      "requires": {
+        "@nomicfoundation/ethereumjs-util": "8.0.6",
+        "crc-32": "^1.2.0"
+      }
+    },
+    "@nomicfoundation/ethereumjs-ethash": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-ethash/-/ethereumjs-ethash-2.0.5.tgz",
+      "integrity": "sha512-xlLdcICGgAYyYmnI3r1t0R5fKGBJNDQSOQxXNjVO99JmxJIdXR5MgPo5CSJO1RpyzKOgzi3uIFn8agv564dZEQ==",
+      "requires": {
+        "@nomicfoundation/ethereumjs-block": "4.2.2",
+        "@nomicfoundation/ethereumjs-rlp": "4.0.3",
+        "@nomicfoundation/ethereumjs-util": "8.0.6",
+        "abstract-level": "^1.0.3",
+        "bigint-crypto-utils": "^3.0.23",
+        "ethereum-cryptography": "0.1.3"
+      }
+    },
+    "@nomicfoundation/ethereumjs-evm": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-evm/-/ethereumjs-evm-1.3.2.tgz",
+      "integrity": "sha512-I00d4MwXuobyoqdPe/12dxUQxTYzX8OckSaWsMcWAfQhgVDvBx6ffPyP/w1aL0NW7MjyerySPcSVfDJAMHjilw==",
+      "requires": {
+        "@nomicfoundation/ethereumjs-common": "3.1.2",
+        "@nomicfoundation/ethereumjs-util": "8.0.6",
+        "@types/async-eventemitter": "^0.2.1",
+        "async-eventemitter": "^0.2.4",
+        "debug": "^4.3.3",
+        "ethereum-cryptography": "0.1.3",
+        "mcl-wasm": "^0.7.1",
+        "rustbn.js": "~0.2.0"
+      }
+    },
+    "@nomicfoundation/ethereumjs-rlp": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-rlp/-/ethereumjs-rlp-4.0.3.tgz",
+      "integrity": "sha512-DZMzB/lqPK78T6MluyXqtlRmOMcsZbTTbbEyAjo0ncaff2mqu/k8a79PBcyvpgAhWD/R59Fjq/x3ro5Lof0AtA=="
+    },
+    "@nomicfoundation/ethereumjs-statemanager": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-statemanager/-/ethereumjs-statemanager-1.0.5.tgz",
+      "integrity": "sha512-CAhzpzTR5toh/qOJIZUUOnWekUXuRqkkzaGAQrVcF457VhtCmr+ddZjjK50KNZ524c1XP8cISguEVNqJ6ij1sA==",
+      "requires": {
+        "@nomicfoundation/ethereumjs-common": "3.1.2",
+        "@nomicfoundation/ethereumjs-rlp": "4.0.3",
+        "@nomicfoundation/ethereumjs-trie": "5.0.5",
+        "@nomicfoundation/ethereumjs-util": "8.0.6",
+        "debug": "^4.3.3",
+        "ethereum-cryptography": "0.1.3",
+        "functional-red-black-tree": "^1.0.1"
+      }
+    },
+    "@nomicfoundation/ethereumjs-trie": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-trie/-/ethereumjs-trie-5.0.5.tgz",
+      "integrity": "sha512-+8sNZrXkzvA1NH5F4kz5RSYl1I6iaRz7mAZRsyxOm0IVY4UaP43Ofvfp/TwOalFunurQrYB5pRO40+8FBcxFMA==",
+      "requires": {
+        "@nomicfoundation/ethereumjs-rlp": "4.0.3",
+        "@nomicfoundation/ethereumjs-util": "8.0.6",
+        "ethereum-cryptography": "0.1.3",
+        "readable-stream": "^3.6.0"
+      }
+    },
+    "@nomicfoundation/ethereumjs-tx": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-tx/-/ethereumjs-tx-4.1.2.tgz",
+      "integrity": "sha512-emJBJZpmTdUa09cqxQqHaysbBI9Od353ZazeH7WgPb35miMgNY6mb7/3vBA98N5lUW/rgkiItjX0KZfIzihSoQ==",
+      "requires": {
+        "@nomicfoundation/ethereumjs-common": "3.1.2",
+        "@nomicfoundation/ethereumjs-rlp": "4.0.3",
+        "@nomicfoundation/ethereumjs-util": "8.0.6",
+        "ethereum-cryptography": "0.1.3"
+      }
+    },
+    "@nomicfoundation/ethereumjs-util": {
+      "version": "8.0.6",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-util/-/ethereumjs-util-8.0.6.tgz",
+      "integrity": "sha512-jOQfF44laa7xRfbfLXojdlcpkvxeHrE2Xu7tSeITsWFgoII163MzjOwFEzSNozHYieFysyoEMhCdP+NY5ikstw==",
+      "requires": {
+        "@nomicfoundation/ethereumjs-rlp": "4.0.3",
+        "ethereum-cryptography": "0.1.3"
+      }
+    },
+    "@nomicfoundation/ethereumjs-vm": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-vm/-/ethereumjs-vm-6.4.2.tgz",
+      "integrity": "sha512-PRTyxZMP6kx+OdAzBhuH1LD2Yw+hrSpaytftvaK//thDy2OI07S0nrTdbrdk7b8ZVPAc9H9oTwFBl3/wJ3w15g==",
+      "requires": {
+        "@nomicfoundation/ethereumjs-block": "4.2.2",
+        "@nomicfoundation/ethereumjs-blockchain": "6.2.2",
+        "@nomicfoundation/ethereumjs-common": "3.1.2",
+        "@nomicfoundation/ethereumjs-evm": "1.3.2",
+        "@nomicfoundation/ethereumjs-rlp": "4.0.3",
+        "@nomicfoundation/ethereumjs-statemanager": "1.0.5",
+        "@nomicfoundation/ethereumjs-trie": "5.0.5",
+        "@nomicfoundation/ethereumjs-tx": "4.1.2",
+        "@nomicfoundation/ethereumjs-util": "8.0.6",
+        "@types/async-eventemitter": "^0.2.1",
+        "async-eventemitter": "^0.2.4",
+        "debug": "^4.3.3",
+        "ethereum-cryptography": "0.1.3",
+        "functional-red-black-tree": "^1.0.1",
+        "mcl-wasm": "^0.7.1",
+        "rustbn.js": "~0.2.0"
+      }
+    },
+    "@nomicfoundation/hardhat-network-helpers": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-network-helpers/-/hardhat-network-helpers-1.0.9.tgz",
+      "integrity": "sha512-OXWCv0cHpwLUO2u7bFxBna6dQtCC2Gg/aN/KtJLO7gmuuA28vgmVKYFRCDUqrbjujzgfwQ2aKyZ9Y3vSmDqS7Q==",
+      "dev": true,
+      "requires": {
+        "ethereumjs-util": "^7.1.4"
+      }
+    },
+    "@nomicfoundation/solidity-analyzer": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer/-/solidity-analyzer-0.1.1.tgz",
+      "integrity": "sha512-1LMtXj1puAxyFusBgUIy5pZk3073cNXYnXUpuNKFghHbIit/xZgbk0AokpUADbNm3gyD6bFWl3LRFh3dhVdREg==",
+      "requires": {
+        "@nomicfoundation/solidity-analyzer-darwin-arm64": "0.1.1",
+        "@nomicfoundation/solidity-analyzer-darwin-x64": "0.1.1",
+        "@nomicfoundation/solidity-analyzer-freebsd-x64": "0.1.1",
+        "@nomicfoundation/solidity-analyzer-linux-arm64-gnu": "0.1.1",
+        "@nomicfoundation/solidity-analyzer-linux-arm64-musl": "0.1.1",
+        "@nomicfoundation/solidity-analyzer-linux-x64-gnu": "0.1.1",
+        "@nomicfoundation/solidity-analyzer-linux-x64-musl": "0.1.1",
+        "@nomicfoundation/solidity-analyzer-win32-arm64-msvc": "0.1.1",
+        "@nomicfoundation/solidity-analyzer-win32-ia32-msvc": "0.1.1",
+        "@nomicfoundation/solidity-analyzer-win32-x64-msvc": "0.1.1"
+      }
+    },
+    "@nomicfoundation/solidity-analyzer-darwin-arm64": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-darwin-arm64/-/solidity-analyzer-darwin-arm64-0.1.1.tgz",
+      "integrity": "sha512-KcTodaQw8ivDZyF+D76FokN/HdpgGpfjc/gFCImdLUyqB6eSWVaZPazMbeAjmfhx3R0zm/NYVzxwAokFKgrc0w==",
+      "optional": true
+    },
+    "@nomicfoundation/solidity-analyzer-darwin-x64": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-darwin-x64/-/solidity-analyzer-darwin-x64-0.1.1.tgz",
+      "integrity": "sha512-XhQG4BaJE6cIbjAVtzGOGbK3sn1BO9W29uhk9J8y8fZF1DYz0Doj8QDMfpMu+A6TjPDs61lbsmeYodIDnfveSA==",
+      "optional": true
+    },
+    "@nomicfoundation/solidity-analyzer-freebsd-x64": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-freebsd-x64/-/solidity-analyzer-freebsd-x64-0.1.1.tgz",
+      "integrity": "sha512-GHF1VKRdHW3G8CndkwdaeLkVBi5A9u2jwtlS7SLhBc8b5U/GcoL39Q+1CSO3hYqePNP+eV5YI7Zgm0ea6kMHoA==",
+      "optional": true
+    },
+    "@nomicfoundation/solidity-analyzer-linux-arm64-gnu": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-linux-arm64-gnu/-/solidity-analyzer-linux-arm64-gnu-0.1.1.tgz",
+      "integrity": "sha512-g4Cv2fO37ZsUENQ2vwPnZc2zRenHyAxHcyBjKcjaSmmkKrFr64yvzeNO8S3GBFCo90rfochLs99wFVGT/0owpg==",
+      "optional": true
+    },
+    "@nomicfoundation/solidity-analyzer-linux-arm64-musl": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-linux-arm64-musl/-/solidity-analyzer-linux-arm64-musl-0.1.1.tgz",
+      "integrity": "sha512-WJ3CE5Oek25OGE3WwzK7oaopY8xMw9Lhb0mlYuJl/maZVo+WtP36XoQTb7bW/i8aAdHW5Z+BqrHMux23pvxG3w==",
+      "optional": true
+    },
+    "@nomicfoundation/solidity-analyzer-linux-x64-gnu": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-linux-x64-gnu/-/solidity-analyzer-linux-x64-gnu-0.1.1.tgz",
+      "integrity": "sha512-5WN7leSr5fkUBBjE4f3wKENUy9HQStu7HmWqbtknfXkkil+eNWiBV275IOlpXku7v3uLsXTOKpnnGHJYI2qsdA==",
+      "optional": true
+    },
+    "@nomicfoundation/solidity-analyzer-linux-x64-musl": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-linux-x64-musl/-/solidity-analyzer-linux-x64-musl-0.1.1.tgz",
+      "integrity": "sha512-KdYMkJOq0SYPQMmErv/63CwGwMm5XHenEna9X9aB8mQmhDBrYrlAOSsIPgFCUSL0hjxE3xHP65/EPXR/InD2+w==",
+      "optional": true
+    },
+    "@nomicfoundation/solidity-analyzer-win32-arm64-msvc": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-win32-arm64-msvc/-/solidity-analyzer-win32-arm64-msvc-0.1.1.tgz",
+      "integrity": "sha512-VFZASBfl4qiBYwW5xeY20exWhmv6ww9sWu/krWSesv3q5hA0o1JuzmPHR4LPN6SUZj5vcqci0O6JOL8BPw+APg==",
+      "optional": true
+    },
+    "@nomicfoundation/solidity-analyzer-win32-ia32-msvc": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-win32-ia32-msvc/-/solidity-analyzer-win32-ia32-msvc-0.1.1.tgz",
+      "integrity": "sha512-JnFkYuyCSA70j6Si6cS1A9Gh1aHTEb8kOTBApp/c7NRTFGNMH8eaInKlyuuiIbvYFhlXW4LicqyYuWNNq9hkpQ==",
+      "optional": true
+    },
+    "@nomicfoundation/solidity-analyzer-win32-x64-msvc": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-win32-x64-msvc/-/solidity-analyzer-win32-x64-msvc-0.1.1.tgz",
+      "integrity": "sha512-HrVJr6+WjIXGnw3Q9u6KQcbZCtk0caVWhCdFADySvRyUxJ8PnzlaP+MhwNE8oyT8OZ6ejHBRrrgjSqDCFXGirw==",
+      "optional": true
     },
     "@nomiclabs/ethereumjs-vm": {
       "version": "4.2.2",
@@ -27592,8 +28716,7 @@
     "@scure/base": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.3.tgz",
-      "integrity": "sha512-/+SgoRjLq7Xlf0CWuLHq2LUZeL/w65kfzAPG5NH9pcmBhs+nunQTn4gvdwgMTIXnt9b2C/1SeL2XiysZEyIC9Q==",
-      "dev": true
+      "integrity": "sha512-/+SgoRjLq7Xlf0CWuLHq2LUZeL/w65kfzAPG5NH9pcmBhs+nunQTn4gvdwgMTIXnt9b2C/1SeL2XiysZEyIC9Q=="
     },
     "@scure/bip32": {
       "version": "1.3.1",
@@ -29665,10 +30788,13 @@
         "ethers": "^5.0.2"
       }
     },
-    "@types/abstract-leveldown": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@types/abstract-leveldown/-/abstract-leveldown-7.2.0.tgz",
-      "integrity": "sha512-q5veSX6zjUy/DlDhR4Y4cU0k2Ar+DT2LUraP00T19WLmTO6Se1djepCCaqU6nQrwcJ5Hyo/CWqxTzrrFg8eqbQ=="
+    "@types/async-eventemitter": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@types/async-eventemitter/-/async-eventemitter-0.2.4.tgz",
+      "integrity": "sha512-2Bq61VD01kgLf1XkK2xPtoBcu7fgn/km5JyEX9v0BlG5VQBzA+BlF9umFk+8gR8S4+eK7MgDY2oyVZCu6ar3Jw==",
+      "requires": {
+        "@types/events": "*"
+      }
     },
     "@types/bn.js": {
       "version": "5.1.2",
@@ -29704,6 +30830,11 @@
         "@types/node": "*"
       }
     },
+    "@types/events": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.3.tgz",
+      "integrity": "sha512-trOc4AAUThEz9hapPtSd7wf5tiQKvTtu5b371UxXdTuqzIh0ArcRspRP0i0Viu+LXstIQ1z96t1nsPxT9ol01g=="
+    },
     "@types/form-data": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-0.0.33.tgz",
@@ -29734,21 +30865,6 @@
       "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
       "dev": true,
       "requires": {
-        "@types/node": "*"
-      }
-    },
-    "@types/level-errors": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/level-errors/-/level-errors-3.0.0.tgz",
-      "integrity": "sha512-/lMtoq/Cf/2DVOm6zE6ORyOM+3ZVm/BvzEZVxUhf6bgh8ZHglXlBqxbxSlJeVp8FCbD3IVvk/VbsaNmDjrQvqQ=="
-    },
-    "@types/levelup": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/@types/levelup/-/levelup-4.3.3.tgz",
-      "integrity": "sha512-K+OTIjJcZHVlZQN1HmU64VtrC0jC3dXWQozuEIR9zVvltIk90zaGPM2AgT+fIkChpzHhFE3YnvFLCbLtzAmexA==",
-      "requires": {
-        "@types/abstract-leveldown": "*",
-        "@types/level-errors": "*",
         "@types/node": "*"
       }
     },
@@ -29893,16 +31009,29 @@
       "integrity": "sha512-JMJ5soJWP18htbbxJjG7bG6yuI6pRhgJ0scHHTfkUjf6wjP912xZWvM+A4sJK3gqd9E8fcPbDnOefbA9Th/FIQ==",
       "dev": true
     },
-    "abstract-leveldown": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.3.0.tgz",
-      "integrity": "sha512-TU5nlYgta8YrBMNpc9FwQzRbiXsj49gsALsXadbGHt9CROPzX5fB0rWDR5mtdpOOKa5XqRFpbj1QroPAoPzVjQ==",
+    "abstract-level": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/abstract-level/-/abstract-level-1.0.4.tgz",
+      "integrity": "sha512-eUP/6pbXBkMbXFdx4IH2fVgvB7M0JvR7/lIL33zcs0IBcwjdzSSl31TOJsaCzmKSSDF9h8QYSOJux4Nd4YJqFg==",
       "requires": {
-        "buffer": "^5.5.0",
-        "immediate": "^3.2.3",
-        "level-concat-iterator": "~2.0.0",
-        "level-supports": "~1.0.0",
-        "xtend": "~4.0.0"
+        "buffer": "^6.0.3",
+        "catering": "^2.1.0",
+        "is-buffer": "^2.0.5",
+        "level-supports": "^4.0.0",
+        "level-transcoder": "^1.0.1",
+        "module-error": "^1.0.1",
+        "queue-microtask": "^1.2.3"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.2.1"
+          }
+        }
       }
     },
     "accepts": {
@@ -29937,6 +31066,15 @@
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
       "requires": {
         "debug": "4"
+      }
+    },
+    "aggregate-error": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+      "requires": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
       }
     },
     "ajv": {
@@ -30160,6 +31298,11 @@
       "integrity": "sha512-bCtHMwL9LeDIozFn+oNhhFoq+yQ3BNdnsLSASUxLciOb1vgvpHsIO1dsENiGMgbb4SkP5TrzWzRiLddn8ahVOQ==",
       "dev": true
     },
+    "bigint-crypto-utils": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/bigint-crypto-utils/-/bigint-crypto-utils-3.3.0.tgz",
+      "integrity": "sha512-jOTSb+drvEDxEq6OuUybOAv/xxoh3cuYRUIPyu8sSHQNKM303UQ2R1DAo45o1AkcIXw6fzbaFI1+xGGdaXs2lg=="
+    },
     "bignumber.js": {
       "version": "9.0.2",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.2.tgz",
@@ -30266,6 +31409,17 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
+    },
+    "browser-level": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/browser-level/-/browser-level-1.0.1.tgz",
+      "integrity": "sha512-XECYKJ+Dbzw0lbydyQuJzwNXtOpbMSq737qxJN11sIRTErOMShvDpbzTlgju7orJKvx4epULolZAuJGLzCmWRQ==",
+      "requires": {
+        "abstract-level": "^1.0.2",
+        "catering": "^2.1.1",
+        "module-error": "^1.0.2",
+        "run-parallel-limit": "^1.1.0"
+      }
     },
     "browser-stdout": {
       "version": "1.3.1",
@@ -30485,6 +31639,11 @@
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
+    "catering": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/catering/-/catering-2.1.1.tgz",
+      "integrity": "sha512-K7Qy8O9p76sL3/3m7/zLKbRkyOlSZAgzEaLhyj2mXS8PsCud2Eo4hAb8aLtZqHh0QGqLcb9dlJSu6lHRVENm1w=="
+    },
     "cbor": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/cbor/-/cbor-5.2.0.tgz",
@@ -30695,6 +31854,23 @@
       "resolved": "https://registry.npmjs.org/class-is/-/class-is-1.1.0.tgz",
       "integrity": "sha512-rhjH9AG1fvabIDoGRVH587413LPjTZgmDF9fOFCbFJQV4yuocX1mHxxvXI4g3cGwbVY9wAYIoKlg1N79frJKQw==",
       "dev": true
+    },
+    "classic-level": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/classic-level/-/classic-level-1.4.1.tgz",
+      "integrity": "sha512-qGx/KJl3bvtOHrGau2WklEZuXhS3zme+jf+fsu6Ej7W7IP/C49v7KNlWIsT1jZu0YnfzSIYDGcEWpCa1wKGWXQ==",
+      "requires": {
+        "abstract-level": "^1.0.2",
+        "catering": "^2.1.0",
+        "module-error": "^1.0.1",
+        "napi-macros": "^2.2.2",
+        "node-gyp-build": "^4.3.0"
+      }
+    },
+    "clean-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A=="
     },
     "cli-table3": {
       "version": "0.5.1",
@@ -31078,9 +32254,9 @@
       "dev": true
     },
     "debug": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "requires": {
         "ms": "2.1.2"
       }
@@ -31133,29 +32309,6 @@
       "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
       "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
       "dev": true
-    },
-    "deferred-leveldown": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-5.3.0.tgz",
-      "integrity": "sha512-a59VOT+oDy7vtAbLRCZwWgxu2BaCfd5Hk7wxJd48ei7I+nsg8Orlb9CLG0PMZienk9BSUKgeAqkO2+Lw+1+Ukw==",
-      "requires": {
-        "abstract-leveldown": "~6.2.1",
-        "inherits": "^2.0.3"
-      },
-      "dependencies": {
-        "abstract-leveldown": {
-          "version": "6.2.3",
-          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.2.3.tgz",
-          "integrity": "sha512-BsLm5vFMRUrrLeCcRc+G0t2qOaTzpoJQLOubq2XM72eNpjF5UdU5o/5NvlNhx95XHcAvcl8OMXr4mlg/fRgUXQ==",
-          "requires": {
-            "buffer": "^5.5.0",
-            "immediate": "^3.2.3",
-            "level-concat-iterator": "~2.0.0",
-            "level-supports": "~1.0.0",
-            "xtend": "~4.0.0"
-          }
-        }
-      }
     },
     "define-properties": {
       "version": "1.1.3",
@@ -31353,17 +32506,6 @@
       "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
       "dev": true
     },
-    "encoding-down": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/encoding-down/-/encoding-down-6.3.0.tgz",
-      "integrity": "sha512-QKrV0iKR6MZVJV08QY0wp1e7vF6QbhnbQhb07bwpEyuz4uZiZgPlEGdkCROuFkUwdxlFaiPIhjyarH1ee/3vhw==",
-      "requires": {
-        "abstract-leveldown": "^6.2.1",
-        "inherits": "^2.0.3",
-        "level-codec": "^9.0.0",
-        "level-errors": "^2.0.0"
-      }
-    },
     "end-of-stream": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
@@ -31496,6 +32638,11 @@
         "d": "^1.0.1",
         "ext": "^1.1.2"
       }
+    },
+    "escalade": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
+      "integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA=="
     },
     "escape-html": {
       "version": "1.0.3",
@@ -31726,33 +32873,6 @@
             "async-limiter": "~1.0.0",
             "safe-buffer": "~5.1.0",
             "ultron": "~1.1.0"
-          }
-        }
-      }
-    },
-    "eth-sig-util": {
-      "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-2.5.4.tgz",
-      "integrity": "sha512-aCMBwp8q/4wrW4QLsF/HYBOSA7TpLKmkVwP3pYQNkEEseW2Rr8Z5Uxc9/h6HX+OG3tuHo+2bINVSihIeBfym6A==",
-      "requires": {
-        "ethereumjs-abi": "0.6.8",
-        "ethereumjs-util": "^5.1.1",
-        "tweetnacl": "^1.0.3",
-        "tweetnacl-util": "^0.15.0"
-      },
-      "dependencies": {
-        "ethereumjs-util": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
-          "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
-          "requires": {
-            "bn.js": "^4.11.0",
-            "create-hash": "^1.1.2",
-            "elliptic": "^6.5.2",
-            "ethereum-cryptography": "^0.1.3",
-            "ethjs-util": "^0.1.3",
-            "rlp": "^2.0.0",
-            "safe-buffer": "^5.1.1"
           }
         }
       }
@@ -40068,22 +41188,29 @@
       }
     },
     "hardhat": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/hardhat/-/hardhat-2.8.2.tgz",
-      "integrity": "sha512-cBUqzZGOi+lwKHArWl5Be7zeFIwlu1IUXOna6k5XhORZ8hAWDVbAJBVfxgmjkcX5GffIf0C5g841zRxo36sQ5g==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/hardhat/-/hardhat-2.13.0.tgz",
+      "integrity": "sha512-ZlzBOLML1QGlm6JWyVAG8lVTEAoOaVm1in/RU2zoGAnYEoD1Rp4T+ZMvrLNhHaaeS9hfjJ1gJUBfiDr4cx+htQ==",
       "requires": {
-        "@ethereumjs/block": "^3.6.0",
-        "@ethereumjs/blockchain": "^5.5.0",
-        "@ethereumjs/common": "^2.6.0",
-        "@ethereumjs/tx": "^3.4.0",
-        "@ethereumjs/vm": "^5.6.0",
         "@ethersproject/abi": "^5.1.2",
+        "@metamask/eth-sig-util": "^4.0.0",
+        "@nomicfoundation/ethereumjs-block": "^4.0.0",
+        "@nomicfoundation/ethereumjs-blockchain": "^6.0.0",
+        "@nomicfoundation/ethereumjs-common": "^3.0.0",
+        "@nomicfoundation/ethereumjs-evm": "^1.0.0",
+        "@nomicfoundation/ethereumjs-rlp": "^4.0.0",
+        "@nomicfoundation/ethereumjs-statemanager": "^1.0.0",
+        "@nomicfoundation/ethereumjs-trie": "^5.0.0",
+        "@nomicfoundation/ethereumjs-tx": "^4.0.0",
+        "@nomicfoundation/ethereumjs-util": "^8.0.0",
+        "@nomicfoundation/ethereumjs-vm": "^6.0.0",
+        "@nomicfoundation/solidity-analyzer": "^0.1.0",
         "@sentry/node": "^5.18.1",
-        "@solidity-parser/parser": "^0.14.0",
         "@types/bn.js": "^5.1.0",
         "@types/lru-cache": "^5.1.0",
         "abort-controller": "^3.0.0",
         "adm-zip": "^0.4.16",
+        "aggregate-error": "^3.0.0",
         "ansi-escapes": "^4.3.0",
         "chalk": "^2.4.2",
         "chokidar": "^3.4.0",
@@ -40091,36 +41218,79 @@
         "debug": "^4.1.1",
         "enquirer": "^2.3.0",
         "env-paths": "^2.2.0",
-        "eth-sig-util": "^2.5.2",
-        "ethereum-cryptography": "^0.1.2",
+        "ethereum-cryptography": "^1.0.3",
         "ethereumjs-abi": "^0.6.8",
-        "ethereumjs-util": "^7.1.3",
         "find-up": "^2.1.0",
         "fp-ts": "1.19.3",
         "fs-extra": "^7.0.1",
-        "glob": "^7.1.3",
-        "https-proxy-agent": "^5.0.0",
+        "glob": "7.2.0",
         "immutable": "^4.0.0-rc.12",
         "io-ts": "1.10.4",
+        "keccak": "^3.0.2",
         "lodash": "^4.17.11",
-        "merkle-patricia-tree": "^4.2.2",
         "mnemonist": "^0.38.0",
-        "mocha": "^7.2.0",
-        "node-fetch": "^2.6.0",
+        "mocha": "^10.0.0",
+        "p-map": "^4.0.0",
         "qs": "^6.7.0",
         "raw-body": "^2.4.1",
         "resolve": "1.17.0",
         "semver": "^6.3.0",
-        "slash": "^3.0.0",
         "solc": "0.7.3",
         "source-map-support": "^0.5.13",
         "stacktrace-parser": "^0.1.10",
-        "true-case-path": "^2.2.1",
         "tsort": "0.0.1",
+        "undici": "^5.14.0",
         "uuid": "^8.3.2",
         "ws": "^7.4.6"
       },
       "dependencies": {
+        "@noble/hashes": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.2.0.tgz",
+          "integrity": "sha512-FZfhjEDbT5GRswV3C6uvLPHMiVD6lQBmpoX5+eSiPaMTXte/IKqI5dykDxzZB/WBeK/CDuQRBWarPdi3FNY2zQ=="
+        },
+        "@scure/bip32": {
+          "version": "1.1.5",
+          "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.1.5.tgz",
+          "integrity": "sha512-XyNh1rB0SkEqd3tXcXMi+Xe1fvg+kUIcoRIEujP1Jgv7DqW2r9lg3Ah0NkFaCs9sTkQAQA8kw7xiRXzENi9Rtw==",
+          "requires": {
+            "@noble/hashes": "~1.2.0",
+            "@noble/secp256k1": "~1.7.0",
+            "@scure/base": "~1.1.0"
+          }
+        },
+        "@scure/bip39": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.1.1.tgz",
+          "integrity": "sha512-t+wDck2rVkh65Hmv280fYdVdY25J9YeEUIgn2LG1WM6gxFkGzcksoDiUkWVpVp3Oex9xGC68JU2dSbUfwZ2jPg==",
+          "requires": {
+            "@noble/hashes": "~1.2.0",
+            "@scure/base": "~1.1.0"
+          }
+        },
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+        },
+        "argparse": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+        },
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "camelcase": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+          "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA=="
+        },
         "chalk": {
           "version": "2.4.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -40131,6 +41301,73 @@
             "supports-color": "^5.3.0"
           }
         },
+        "cliui": {
+          "version": "7.0.4",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+          "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.0",
+            "wrap-ansi": "^7.0.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "decamelize": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+          "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ=="
+        },
+        "diff": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+          "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w=="
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+        },
+        "ethereum-cryptography": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-1.2.0.tgz",
+          "integrity": "sha512-6yFQC9b5ug6/17CQpCyE3k9eKBMdhyVjzUy1WkiuY/E4vj/SXDBbCw8QEIaXqf0Mf2SnY6RmpDcwlUmBSS0EJw==",
+          "requires": {
+            "@noble/hashes": "1.2.0",
+            "@noble/secp256k1": "1.7.1",
+            "@scure/bip32": "1.1.5",
+            "@scure/bip39": "1.1.1"
+          }
+        },
+        "flat": {
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+          "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ=="
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+        },
+        "js-yaml": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+          "requires": {
+            "argparse": "^2.0.1"
+          }
+        },
         "jsonfile": {
           "version": "2.4.0",
           "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
@@ -40138,6 +41375,157 @@
           "requires": {
             "graceful-fs": "^4.1.6"
           }
+        },
+        "locate-path": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+          "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+          "requires": {
+            "p-locate": "^5.0.0"
+          }
+        },
+        "log-symbols": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+          "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+          "requires": {
+            "chalk": "^4.1.0",
+            "is-unicode-supported": "^0.1.0"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "4.3.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+              "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+              "requires": {
+                "color-convert": "^2.0.1"
+              }
+            },
+            "chalk": {
+              "version": "4.1.2",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+              "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+              "requires": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+              }
+            },
+            "has-flag": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+              "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+            },
+            "supports-color": {
+              "version": "7.2.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+              "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+              "requires": {
+                "has-flag": "^4.0.0"
+              }
+            }
+          }
+        },
+        "minimatch": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
+          "integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        },
+        "mocha": {
+          "version": "10.3.0",
+          "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.3.0.tgz",
+          "integrity": "sha512-uF2XJs+7xSLsrmIvn37i/wnc91nw7XjOQB8ccyx5aEgdnohr7n+rEiZP23WkCYHjilR6+EboEnbq/ZQDz4LSbg==",
+          "requires": {
+            "ansi-colors": "4.1.1",
+            "browser-stdout": "1.3.1",
+            "chokidar": "3.5.3",
+            "debug": "4.3.4",
+            "diff": "5.0.0",
+            "escape-string-regexp": "4.0.0",
+            "find-up": "5.0.0",
+            "glob": "8.1.0",
+            "he": "1.2.0",
+            "js-yaml": "4.1.0",
+            "log-symbols": "4.1.0",
+            "minimatch": "5.0.1",
+            "ms": "2.1.3",
+            "serialize-javascript": "6.0.0",
+            "strip-json-comments": "3.1.1",
+            "supports-color": "8.1.1",
+            "workerpool": "6.2.1",
+            "yargs": "16.2.0",
+            "yargs-parser": "20.2.4",
+            "yargs-unparser": "2.0.0"
+          },
+          "dependencies": {
+            "escape-string-regexp": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+              "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
+            },
+            "find-up": {
+              "version": "5.0.0",
+              "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+              "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+              "requires": {
+                "locate-path": "^6.0.0",
+                "path-exists": "^4.0.0"
+              }
+            },
+            "glob": {
+              "version": "8.1.0",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+              "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+              "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^5.0.1",
+                "once": "^1.3.0"
+              }
+            },
+            "has-flag": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+              "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+            },
+            "supports-color": {
+              "version": "8.1.1",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+              "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+              "requires": {
+                "has-flag": "^4.0.0"
+              }
+            }
+          }
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+        },
+        "p-limit": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+          "requires": {
+            "yocto-queue": "^0.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+          "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+          "requires": {
+            "p-limit": "^3.0.2"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
         },
         "solc": {
           "version": "0.7.3",
@@ -40174,12 +41562,90 @@
             }
           }
         },
+        "string-width": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        },
+        "strip-json-comments": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+          "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="
+        },
         "supports-color": {
           "version": "5.5.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
           "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "requires": {
             "has-flag": "^3.0.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+          "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "4.3.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+              "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+              "requires": {
+                "color-convert": "^2.0.1"
+              }
+            }
+          }
+        },
+        "y18n": {
+          "version": "5.0.8",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+          "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="
+        },
+        "yargs": {
+          "version": "16.2.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+          "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+          "requires": {
+            "cliui": "^7.0.2",
+            "escalade": "^3.1.1",
+            "get-caller-file": "^2.0.5",
+            "require-directory": "^2.1.1",
+            "string-width": "^4.2.0",
+            "y18n": "^5.0.5",
+            "yargs-parser": "^20.2.2"
+          }
+        },
+        "yargs-parser": {
+          "version": "20.2.4",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
+          "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA=="
+        },
+        "yargs-unparser": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+          "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+          "requires": {
+            "camelcase": "^6.0.0",
+            "decamelize": "^4.0.0",
+            "flat": "^5.0.2",
+            "is-plain-obj": "^2.1.0"
           }
         }
       }
@@ -40877,6 +42343,11 @@
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.0.0.tgz",
       "integrity": "sha512-zIE9hX70qew5qTUjSS7wi1iwj/l7+m54KWU247nhM3v806UdGj1yDndXj+IOYxxtW9zyLI+xqFNZjTuDaLUqFw=="
     },
+    "indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="
+    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -41072,6 +42543,11 @@
         "has-tostringtag": "^1.0.0"
       }
     },
+    "is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="
+    },
     "is-regex": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
@@ -41115,6 +42591,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
+    "is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw=="
     },
     "is-upper-case": {
       "version": "1.1.2",
@@ -41285,6 +42766,16 @@
         "invert-kv": "^1.0.0"
       }
     },
+    "level": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/level/-/level-8.0.1.tgz",
+      "integrity": "sha512-oPBGkheysuw7DmzFQYyFe8NAia5jFLAgEnkgWnK3OXAuJr8qFT+xBQIwokAZPME2bhPFzS8hlYcL16m8UZrtwQ==",
+      "requires": {
+        "abstract-level": "^1.0.4",
+        "browser-level": "^1.0.1",
+        "classic-level": "^1.2.0"
+      }
+    },
     "level-codec": {
       "version": "9.0.2",
       "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-9.0.2.tgz",
@@ -41292,11 +42783,6 @@
       "requires": {
         "buffer": "^5.6.0"
       }
-    },
-    "level-concat-iterator": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/level-concat-iterator/-/level-concat-iterator-2.0.1.tgz",
-      "integrity": "sha512-OTKKOqeav2QWcERMJR7IS9CUo1sHnke2C0gkSmcR7QuEtFNLLzHQAvnMw8ykvEcv0Qtkg0p7FOwP1v9e5Smdcw=="
     },
     "level-errors": {
       "version": "2.0.1",
@@ -41306,62 +42792,29 @@
         "errno": "~0.1.1"
       }
     },
-    "level-iterator-stream": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-4.0.2.tgz",
-      "integrity": "sha512-ZSthfEqzGSOMWoUGhTXdX9jv26d32XJuHz/5YnuHZzH6wldfWMOVwI9TBtKcya4BKTyTt3XVA0A3cF3q5CY30Q==",
-      "requires": {
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0",
-        "xtend": "^4.0.2"
-      }
-    },
-    "level-mem": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/level-mem/-/level-mem-5.0.1.tgz",
-      "integrity": "sha512-qd+qUJHXsGSFoHTziptAKXoLX87QjR7v2KMbqncDXPxQuCdsQlzmyX+gwrEHhlzn08vkf8TyipYyMmiC6Gobzg==",
-      "requires": {
-        "level-packager": "^5.0.3",
-        "memdown": "^5.0.0"
-      }
-    },
-    "level-packager": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/level-packager/-/level-packager-5.1.1.tgz",
-      "integrity": "sha512-HMwMaQPlTC1IlcwT3+swhqf/NUO+ZhXVz6TY1zZIIZlIR0YSn8GtAAWmIvKjNY16ZkEg/JcpAuQskxsXqC0yOQ==",
-      "requires": {
-        "encoding-down": "^6.3.0",
-        "levelup": "^4.3.2"
-      }
-    },
     "level-supports": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-4.0.1.tgz",
+      "integrity": "sha512-PbXpve8rKeNcZ9C1mUicC9auIYFyGpkV9/i6g76tLgANwWhtG2v7I4xNBUlkn3lE2/dZF3Pi0ygYGtLc4RXXdA=="
+    },
+    "level-transcoder": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-1.0.1.tgz",
-      "integrity": "sha512-rXM7GYnW8gsl1vedTJIbzOrRv85c/2uCMpiiCzO2fndd06U/kUXEEU9evYn4zFggBOg36IsBW8LzqIpETwwQzg==",
+      "resolved": "https://registry.npmjs.org/level-transcoder/-/level-transcoder-1.0.1.tgz",
+      "integrity": "sha512-t7bFwFtsQeD8cl8NIoQ2iwxA0CL/9IFw7/9gAjOonH0PWTTiRfY7Hq+Ejbsxh86tXobDQ6IOiddjNYIfOBs06w==",
       "requires": {
-        "xtend": "^4.0.2"
-      }
-    },
-    "level-ws": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/level-ws/-/level-ws-2.0.0.tgz",
-      "integrity": "sha512-1iv7VXx0G9ec1isqQZ7y5LmoZo/ewAsyDHNA8EFDW5hqH2Kqovm33nSFkSdnLLAK+I5FlT+lo5Cw9itGe+CpQA==",
-      "requires": {
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.0",
-        "xtend": "^4.0.1"
-      }
-    },
-    "levelup": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/levelup/-/levelup-4.4.0.tgz",
-      "integrity": "sha512-94++VFO3qN95cM/d6eBXvd894oJE0w3cInq9USsyQzzoJxmiYzPAocNcuGCPGGjoXqDVJcr3C1jzt1TSjyaiLQ==",
-      "requires": {
-        "deferred-leveldown": "~5.3.0",
-        "level-errors": "~2.0.0",
-        "level-iterator-stream": "~4.0.0",
-        "level-supports": "~1.0.0",
-        "xtend": "~4.0.0"
+        "buffer": "^6.0.3",
+        "module-error": "^1.0.1"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.2.1"
+          }
+        }
       }
     },
     "levn": {
@@ -41531,36 +42984,14 @@
       "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
       "dev": true
     },
-    "memdown": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/memdown/-/memdown-5.1.0.tgz",
-      "integrity": "sha512-B3J+UizMRAlEArDjWHTMmadet+UKwHd3UjMgGBkZcKAxAYVPS9o0Yeiha4qvz7iGiL2Sb3igUft6p7nbFWctpw==",
+    "memory-level": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/memory-level/-/memory-level-1.0.0.tgz",
+      "integrity": "sha512-UXzwewuWeHBz5krr7EvehKcmLFNoXxGcvuYhC41tRnkrTbJohtS7kVn9akmgirtRygg+f7Yjsfi8Uu5SGSQ4Og==",
       "requires": {
-        "abstract-leveldown": "~6.2.1",
-        "functional-red-black-tree": "~1.0.1",
-        "immediate": "~3.2.3",
-        "inherits": "~2.0.1",
-        "ltgt": "~2.2.0",
-        "safe-buffer": "~5.2.0"
-      },
-      "dependencies": {
-        "abstract-leveldown": {
-          "version": "6.2.3",
-          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.2.3.tgz",
-          "integrity": "sha512-BsLm5vFMRUrrLeCcRc+G0t2qOaTzpoJQLOubq2XM72eNpjF5UdU5o/5NvlNhx95XHcAvcl8OMXr4mlg/fRgUXQ==",
-          "requires": {
-            "buffer": "^5.5.0",
-            "immediate": "^3.2.3",
-            "level-concat-iterator": "~2.0.0",
-            "level-supports": "~1.0.0",
-            "xtend": "~4.0.0"
-          }
-        },
-        "immediate": {
-          "version": "3.2.3",
-          "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.2.3.tgz",
-          "integrity": "sha1-0UD6j2FGWb1lQSMwl92qwlzdmRw="
-        }
+        "abstract-level": "^1.0.0",
+        "functional-red-black-tree": "^1.0.1",
+        "module-error": "^1.0.1"
       }
     },
     "memorystream": {
@@ -41579,19 +43010,6 @@
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
       "dev": true
-    },
-    "merkle-patricia-tree": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/merkle-patricia-tree/-/merkle-patricia-tree-4.2.3.tgz",
-      "integrity": "sha512-S4xevdXl5KvdBGgUxhQcxoep0onqXiIhzfwZp4M78kIuJH3Pu9o9IUgqhzSFOR2ykLO6t265026Xb6PY0q2UFQ==",
-      "requires": {
-        "@types/levelup": "^4.3.0",
-        "ethereumjs-util": "^7.1.4",
-        "level-mem": "^5.0.1",
-        "level-ws": "^2.0.0",
-        "readable-stream": "^3.6.0",
-        "semaphore-async-await": "^1.5.1"
-      }
     },
     "methods": {
       "version": "1.1.2",
@@ -41870,6 +43288,11 @@
       "integrity": "sha512-qYvlv/exQ4+svI3UOvPUpLDF0OMX5euvUH0Ny4N5QyRyhNdgAgUrVH3iUINSzEPLvx0kbo/Bp28GJKIqvE7URw==",
       "dev": true
     },
+    "module-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/module-error/-/module-error-1.0.2.tgz",
+      "integrity": "sha512-0yuvsqSCv8LbaOKhnsQ/T5JhyFlCYLPXK3U2sgV10zoKQwzs/MyfuQUOZQ1V/6OCOJsK/TRgNVrPuPDqtdMFtA=="
+    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -41933,6 +43356,11 @@
       "resolved": "https://registry.npmjs.org/nano-json-stream-parser/-/nano-json-stream-parser-0.1.2.tgz",
       "integrity": "sha512-9MqxMH/BSJC7dnLsEMPyfN5Dvoo49IsPFYMcHw3Bcfc2kN0lpHRBSzlMSVx4HGyJ7s9B31CyBTVehWJoQ8Ctew==",
       "dev": true
+    },
+    "napi-macros": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/napi-macros/-/napi-macros-2.2.2.tgz",
+      "integrity": "sha512-hmEVtAGYzVQpCKdbQea4skABsdXW4RUh5t5mJ2zzqowJS2OyXZTU1KhDVFhx+NlWZ4ap9mqR9TcDO3LTTttd+g=="
     },
     "negotiator": {
       "version": "0.6.3",
@@ -42218,6 +43646,14 @@
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "requires": {
         "p-limit": "^1.1.0"
+      }
+    },
+    "p-map": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+      "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+      "requires": {
+        "aggregate-error": "^3.0.0"
       }
     },
     "p-try": {
@@ -42590,8 +44026,7 @@
     "queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="
     },
     "quick-lru": {
       "version": "5.1.1",
@@ -42916,6 +44351,14 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "run-parallel-limit": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/run-parallel-limit/-/run-parallel-limit-1.1.0.tgz",
+      "integrity": "sha512-jJA7irRNM91jaKc3Hcl1npHsFLOXOoTkPCUL1JEa1R82O2miplXXRaGdjW/KM/98YQWDhJLiSs793CnXfblJUw==",
+      "requires": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
     "rustbn.js": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/rustbn.js/-/rustbn.js-0.2.0.tgz",
@@ -43036,11 +44479,6 @@
       "resolved": "https://registry.npmjs.org/semaphore/-/semaphore-1.1.0.tgz",
       "integrity": "sha512-O4OZEaNtkMd/K0i6js9SL+gqy0ZCBMgUvlSqHKi4IBdjhe7wB8pwztUk1BbZ1fmrvpwFrPbHzqd2w5pTcJH6LA=="
     },
-    "semaphore-async-await": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/semaphore-async-await/-/semaphore-async-await-1.5.1.tgz",
-      "integrity": "sha1-hXvvXjZEYBykuVcLh+nfXKEpdPo="
-    },
     "semver": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -43100,6 +44538,14 @@
       "requires": {
         "no-case": "^2.2.0",
         "upper-case-first": "^1.1.2"
+      }
+    },
+    "serialize-javascript": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
+      "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
+      "requires": {
+        "randombytes": "^2.1.0"
       }
     },
     "serve-static": {
@@ -43248,7 +44694,8 @@
     "slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true
     },
     "snake-case": {
       "version": "2.1.0",
@@ -43846,11 +45293,6 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
     },
-    "true-case-path": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/true-case-path/-/true-case-path-2.2.1.tgz",
-      "integrity": "sha512-0z3j8R7MCjy10kc/g+qg7Ln3alJTodw9aDuVWZa3uiWqfuBMKeAeP2ocWcxoyM3D73yz3Jt/Pu4qPr4wHSdB/Q=="
-    },
     "ts-essentials": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-1.0.4.tgz",
@@ -44002,7 +45444,7 @@
       "version": "4.5.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
       "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
-      "dev": true,
+      "devOptional": true,
       "peer": true
     },
     "typical": {
@@ -44033,6 +45475,14 @@
         "has-bigints": "^1.0.1",
         "has-symbols": "^1.0.2",
         "which-boxed-primitive": "^1.0.2"
+      }
+    },
+    "undici": {
+      "version": "5.28.3",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.3.tgz",
+      "integrity": "sha512-3ItfzbrhDlINjaP0duwnNsKpDQk3acHI3gVJ1z4fmwMK31k5G9OVIAMLSIaP6w4FaGkaAkN6zaQO9LUvZ1t7VA==",
+      "requires": {
+        "@fastify/busboy": "^2.0.0"
       }
     },
     "universalify": {
@@ -46067,6 +47517,11 @@
       "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
       "dev": true
     },
+    "workerpool": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.1.tgz",
+      "integrity": "sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw=="
+    },
     "wrap-ansi": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
@@ -46282,6 +47737,11 @@
         "lodash": "^4.17.15",
         "yargs": "^13.3.0"
       }
+    },
+    "yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
   "name": "pillar-dao-contracts",
   "devDependencies": {
-    "@nomicfoundation/hardhat-network-helpers": "^1.0.9",
+    "@nomicfoundation/hardhat-network-helpers": "1.0.9",
     "@nomiclabs/hardhat-ethers": "2.0.4",
     "@nomiclabs/hardhat-waffle": "2.0.2",
     "@openzeppelin/test-helpers": "0.5.16",
     "chai": "4.3.6",
     "ethereum-waffle": "3.4.0",
     "ethers": "5.5.4",
-    "hardhat": "^2.13.0",
+    "hardhat": "2.13.0",
     "hardhat-tracer": "1.1.0-rc.9",
     "solidity-coverage": "0.7.20"
   },

--- a/package.json
+++ b/package.json
@@ -1,13 +1,14 @@
 {
   "name": "pillar-dao-contracts",
   "devDependencies": {
+    "@nomicfoundation/hardhat-network-helpers": "^1.0.9",
     "@nomiclabs/hardhat-ethers": "2.0.4",
     "@nomiclabs/hardhat-waffle": "2.0.2",
     "@openzeppelin/test-helpers": "0.5.16",
     "chai": "4.3.6",
     "ethereum-waffle": "3.4.0",
     "ethers": "5.5.4",
-    "hardhat": "2.8.2",
+    "hardhat": "^2.13.0",
     "hardhat-tracer": "1.1.0-rc.9",
     "solidity-coverage": "0.7.20"
   },

--- a/scripts/01_dao_deploy_and_setup.js
+++ b/scripts/01_dao_deploy_and_setup.js
@@ -8,20 +8,20 @@ async function main() {
   console.log('Deploying contracts with the account:', deployer.address);
   console.log('Account balance:', (await deployer.getBalance()).toString());
 
-  // Deploy Pillar Token (ONLY FOR TESTING!)
-  const PillarToken = await ethers.getContractFactory('DummyPillarToken');
-  const pillarToken = await PillarToken.deploy();
-  await pillarToken.deployed();
-  console.log('PillarToken address:', pillarToken.address);
+  // // Deploy Pillar Token (ONLY FOR TESTING!)
+  // const PillarToken = await ethers.getContractFactory('DummyPillarToken');
+  // const pillarToken = await PillarToken.deploy();
+  // await pillarToken.deployed();
+  // console.log('PillarToken address:', pillarToken.address);
 
-  // Wait for 10 block transactions to ensure deployment before verifying
-  await pillarToken.deployTransaction.wait(10);
+  // // Wait for 10 block transactions to ensure deployment before verifying
+  // await pillarToken.deployTransaction.wait(10);
 
-  // Verify contract on Etherscan
-  await hre.run('verify:verify', {
-    address: pillarToken.address,
-    contract: 'contracts/testing_utils/DummyPillarToken.sol:DummyPillarToken',
-  });
+  // // Verify contract on Etherscan
+  // await hre.run('verify:verify', {
+  //   address: pillarToken.address,
+  //   contract: 'contracts/testing_utils/DummyPillarToken.sol:DummyPillarToken',
+  // });
 
   // Set values for MembershipNFT deployment
   const name = 'Pillar DAA';
@@ -35,7 +35,7 @@ async function main() {
 
   // Set values for PillarDAO deployment
   const stakingAmount = ethers.utils.parseEther('10000');
-  const values = [stakingToken, stakingAmount, membershipNFT.address];
+  const values = [pillarToken.address, stakingAmount, membershipNFT.address];
 
   // PillarDAO deployment
   const PillarDAOFactory = await ethers.getContractFactory('PillarDAO');

--- a/scripts/02_verify_pillar_dao.js
+++ b/scripts/02_verify_pillar_dao.js
@@ -3,13 +3,29 @@ const { ethers } = require('hardhat');
 
 async function main() {
   // Values to be changed
-  const pillarDAO = '0x7D8107C5000aefaa73b4A31e7B9bDC58D3fdE24b';
+  const pillarDAO = '0xE9a88F0d543d3a0C14E487bed884B3dA49529e48';
   const stakingToken = '0xa6b37fC85d870711C56FbcB8afe2f8dB049AE774'; // PLR Token Polygon
   const stakingAmount = ethers.utils.parseEther('10000');
-  const membershipNFT = '0xdf092214989eD7f73bAEf99D651E5e721e0e7F11';
+  const membershipNFT = '0xFa2d028Ba398C20eE0A7483c00218F91FFEe47c6';
+  const preExistingMembers = [
+    '0x2b9e8c8d9bfB803Fd0E663D6573086Ab8C435098',
+    '0xe55b958B9416adB29909d52D3969F519160e63D8',
+    '0x4414348B92Af7784394fb12F030DF7e8Fd6A2755',
+    '0x65447bC1716b2C8176B9B65FFBc8d882dB6c9766',
+    '0xe9EE49F67eD851e80f1f50D0AF850b37B3D198A6',
+    '0xfF1ED0c529c3a61f6ef61847Cb4331f42e303696',
+    '0xAD1CBFcF53d1F7213D2B6359e8468244e3DE27b2',
+    '0xbe5951e8ab38fe6c0fa6fF1fB44ca3059Ee437Fe',
+    '0x763AAD3f4C936D94D794451dE89D8e3297091205',
+  ];
 
   // PillarDAO constructor arguments
-  const values = [stakingToken, stakingAmount, membershipNFT];
+  const values = [
+    stakingToken,
+    stakingAmount,
+    membershipNFT,
+    preExistingMembers,
+  ];
 
   console.log('Starting verification...');
 

--- a/scripts/04_deploy_new_dao_and_setup.js
+++ b/scripts/04_deploy_new_dao_and_setup.js
@@ -1,0 +1,76 @@
+const hre = require('hardhat');
+
+async function main() {
+  const NFT_IMAGE_LINK = ''; // Set NFT image link
+  const [deployer] = await ethers.getSigners();
+  const stakingToken = '0xa6b37fC85d870711C56FbcB8afe2f8dB049AE774'; // PLR Token Polygon
+  const preExistingMembers = process.env.PRE_EXISTING_MEMBERS;
+
+  console.log('Deploying contracts with the account:', deployer.address);
+  console.log('Account balance:', (await deployer.getBalance()).toString());
+
+  // Set values for PillarDAO deployment
+  const deployedMembershipNFT = '0xFa2d028Ba398C20eE0A7483c00218F91FFEe47c6'; // MembershipNFT Polygon
+  const stakingAmount = ethers.utils.parseEther('10000');
+  const values = [
+    stakingToken,
+    stakingAmount,
+    deployedMembershipNFT,
+    preExistingMembers,
+  ];
+
+  // PillarDAO deployment
+  const PillarDAOFactory = await ethers.getContractFactory('PillarDAO');
+  const pillarDaoContract = await PillarDAOFactory.deploy(...values);
+  await pillarDaoContract.deployed();
+
+  console.log(
+    'Deployed to address with values: ',
+    pillarDaoContract.address,
+    ...values
+  );
+
+  // connect to MembershipNFT and set vault to owner
+  const MembershipNFT = await ethers.getContractFactory('MembershipNFT');
+  const membershipNFT = MembershipNFT.attach(deployedMembershipNFT);
+  await membershipNFT.connect(deployer).setVaultAddress(deployer.address);
+
+  // mint MembershipNFT to existing members without NFT and swap vault to DAO
+  await membershipNFT.mint(preExistingMembers[7]);
+  await membershipNFT.mint(preExistingMembers[8]);
+
+  // check minted NFTs
+  console.log(
+    `${await membershipNFT.ownerOf(8)} should equal ${preExistingMembers[7]}`
+  );
+  console.log(
+    `${await membershipNFT.ownerOf(9)} should equal ${preExistingMembers[8]}`
+  );
+
+  // Set vault address back to DAO contract
+  await membershipNFT
+    .connect(deployer)
+    .setVaultAddress(pillarDaoContract.address);
+  console.log(`Vault Address set to: ${pillarDaoContract.address}`);
+
+  console.log('Starting verification...');
+
+  // Wait for 5 block transactions to ensure deployment before verifying
+  await pillarDaoContract.deployTransaction.wait(15);
+
+  // Verify PillarDAO contract on Etherscan
+  await hre.run('verify:verify', {
+    address: pillarDaoContract.address,
+    contract: 'contracts/PillarDAO.sol:PillarDAO',
+    constructorArguments: [...values],
+  });
+
+  console.log('Completed verification...');
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/scripts/04_deploy_new_dao_and_setup.js
+++ b/scripts/04_deploy_new_dao_and_setup.js
@@ -4,7 +4,21 @@ async function main() {
   const NFT_IMAGE_LINK = ''; // Set NFT image link
   const [deployer] = await ethers.getSigners();
   const stakingToken = '0xa6b37fC85d870711C56FbcB8afe2f8dB049AE774'; // PLR Token Polygon
-  const preExistingMembers = process.env.PRE_EXISTING_MEMBERS;
+  const preExistingMembers = [
+    '0x2b9e8c8d9bfB803Fd0E663D6573086Ab8C435098',
+    '0xe55b958B9416adB29909d52D3969F519160e63D8',
+    '0x4414348B92Af7784394fb12F030DF7e8Fd6A2755',
+    '0x65447bC1716b2C8176B9B65FFBc8d882dB6c9766',
+    '0xe9EE49F67eD851e80f1f50D0AF850b37B3D198A6',
+    '0xfF1ED0c529c3a61f6ef61847Cb4331f42e303696',
+    '0xAD1CBFcF53d1F7213D2B6359e8468244e3DE27b2',
+    '0xbe5951e8ab38fe6c0fa6fF1fB44ca3059Ee437Fe',
+    '0x763AAD3f4C936D94D794451dE89D8e3297091205',
+  ];
+  const memberDepositTimes = [
+    1691684454, 1692039593, 1696258495, 1696338126, 1696355349, 1696544327,
+    1698407526, 1706461032, 1707760153,
+  ];
 
   console.log('Deploying contracts with the account:', deployer.address);
   console.log('Account balance:', (await deployer.getBalance()).toString());
@@ -52,6 +66,34 @@ async function main() {
     .connect(deployer)
     .setVaultAddress(pillarDaoContract.address);
   console.log(`Vault Address set to: ${pillarDaoContract.address}`);
+
+  await pillarDaoContract
+    .connect(deployer)
+    .setDepositTimestamp(preExistingMembers[0], memberDepositTimes[0]);
+  await pillarDaoContract
+    .connect(deployer)
+    .setDepositTimestamp(preExistingMembers[1], memberDepositTimes[1]);
+  await pillarDaoContract
+    .connect(deployer)
+    .setDepositTimestamp(preExistingMembers[2], memberDepositTimes[2]);
+  await pillarDaoContract
+    .connect(deployer)
+    .setDepositTimestamp(preExistingMembers[3], memberDepositTimes[3]);
+  await pillarDaoContract
+    .connect(deployer)
+    .setDepositTimestamp(preExistingMembers[4], memberDepositTimes[4]);
+  await pillarDaoContract
+    .connect(deployer)
+    .setDepositTimestamp(preExistingMembers[5], memberDepositTimes[5]);
+  await pillarDaoContract
+    .connect(deployer)
+    .setDepositTimestamp(preExistingMembers[6], memberDepositTimes[6]);
+  await pillarDaoContract
+    .connect(deployer)
+    .setDepositTimestamp(preExistingMembers[7], memberDepositTimes[7]);
+  await pillarDaoContract
+    .connect(deployer)
+    .setDepositTimestamp(preExistingMembers[8], memberDepositTimes[8]);
 
   console.log('Starting verification...');
 

--- a/test/PillarDAO.spec.js
+++ b/test/PillarDAO.spec.js
@@ -1,45 +1,41 @@
-const { ethers, waffle, network } = require('hardhat');
-const chai = require('chai');
+const { ethers, network } = require('hardhat');
 const { expect } = require('chai');
-const { smock } = require('@defi-wonderland/smock');
-chai.use(smock.matchers);
-
-const token = require('./abi/token.json');
+const { time } = require('@nomicfoundation/hardhat-network-helpers');
 
 const stakingAmount = ethers.utils.parseEther('10000');
+const weeks = 53;
+const secondsInWeek = 7 * 24 * 60 * 60; // Number of seconds in a week
+const secondsIn53Weeks = weeks * secondsInWeek;
 
 describe('PillarDAO', () => {
   let pillarDAO;
   let membershipNFT;
-  let plrToken;
+  let pillarToken;
 
-  let owner;
-  let vault;
-
-  let addr1;
-  let addr2;
-  let addr3;
-
+  let owner, vault, addr1, addr2, pm1, pm2, pm3, pm4, pm5, pm6, pm7, pm8, pm9;
+  let members;
   /* create named accounts for contract roles */
 
-  before(async () => {
+  beforeEach(async () => {
     /* before tests */
-    [owner, addr1, addr2, addr3, vault] = await ethers.getSigners();
+    [owner, vault, addr1, addr2, pm1, pm2, pm3, pm4, pm5, pm6, pm7, pm8, pm9] =
+      await ethers.getSigners();
+    members = [
+      pm1.address,
+      pm2.address,
+      pm3.address,
+      pm4.address,
+      pm5.address,
+      pm6.address,
+      pm7.address,
+      pm8.address,
+      pm9.address,
+    ];
 
-    // creating a fake PLR token
-    plrToken = await smock.fake(token);
-    plrToken.name.returns('Pillar Token');
-    plrToken.symbol.returns('PLR');
-    plrToken.totalSupply.returns(ethers.utils.parseEther('800000000'));
-    plrToken.balanceOf
-      .whenCalledWith(owner)
-      .returns(ethers.utils.parseEther('50000000'));
-    plrToken.balanceOf
-      .whenCalledWith(addr1)
-      .returns(ethers.utils.parseEther('10000'));
-    plrToken.allowance.returns(stakingAmount);
-    plrToken.transferFrom.returns(true);
-    plrToken.transfer.returns(true);
+    // Deploy and setup contracts
+    const PillarToken = await ethers.getContractFactory('DummyPillarToken');
+    pillarToken = await PillarToken.deploy();
+    await pillarToken.deployed();
 
     const MembershipNFTFactory = await ethers.getContractFactory(
       'MembershipNFT'
@@ -52,9 +48,10 @@ describe('PillarDAO', () => {
 
     const DAOFactory = await ethers.getContractFactory('PillarDAO');
     pillarDAO = await DAOFactory.deploy(
-      plrToken.address,
+      pillarToken.address,
       stakingAmount,
-      membershipNFT.address
+      membershipNFT.address,
+      members
     );
     await pillarDAO.deployed();
     await membershipNFT.setVaultAddress(pillarDAO.address);
@@ -63,66 +60,104 @@ describe('PillarDAO', () => {
     );
   });
 
-  it('Deploys without errors', async () => {
-    const stakeAmt = await pillarDAO.stakingAmount();
-    expect(stakeAmt).to.equal(stakingAmount);
+  describe('Deployment', async () => {
+    it('Deploys without errors', async () => {
+      const stakeAmt = await pillarDAO.stakingAmount();
+      expect(stakeAmt).to.equal(stakingAmount);
+    });
   });
 
-  it('deposit() with incorrect amount not allowed', async () => {
-    const stakeAmt = ethers.utils.parseEther('10');
-    const tran = pillarDAO.connect(addr1).deposit(stakeAmt);
-    await expect(tran).to.revertedWith('PillarDAO:: invalid staked amount');
+  describe('Depositing', async () => {
+    it('deposit() with incorrect amount not allowed', async () => {
+      const stakeAmt = ethers.utils.parseEther('10');
+      const tran = pillarDAO.connect(addr1).deposit(stakeAmt);
+      await expect(tran).to.revertedWith('PillarDAO:: invalid staked amount');
+    });
+
+    it('deposit()', async () => {
+      await pillarToken
+        .connect(owner)
+        .approve(pillarDAO.address, stakingAmount);
+      const tran = await pillarDAO.deposit(stakingAmount);
+      const ret = await tran.wait();
+      expect(ret.events.length).to.greaterThan(0);
+    });
+
+    it('deposit() multiple times not allowed', async () => {
+      await pillarToken
+        .connect(owner)
+        .approve(pillarDAO.address, ethers.utils.parseEther('20000'));
+      await pillarDAO.deposit(stakingAmount);
+      const tran = pillarDAO.deposit(stakingAmount);
+      await expect(tran).to.revertedWith(
+        'PillarDAO:: user is already a member'
+      );
+    });
   });
 
-  it('deposit()', async () => {
-    const tran = await pillarDAO.deposit(stakingAmount);
-    const ret = await tran.wait();
-    expect(ret.events.length).to.greaterThan(0);
+  describe('Checking MembershipNFT ID', async () => {
+    it('membershipId()', async () => {
+      await pillarToken
+        .connect(owner)
+        .approve(pillarDAO.address, stakingAmount);
+      await pillarDAO.deposit(stakingAmount);
+      const membershipId = await pillarDAO.membershipId(owner.address);
+      expect(membershipId).to.equal(1);
+    });
   });
 
-  it('deposit() multiple times not allowed', async () => {
-    const tran = pillarDAO.deposit(stakingAmount);
-    await expect(tran).to.revertedWith('PillarDAO:: user is already a member');
+  describe('Checking if user can unstake', async () => {
+    it('canUnstake() - should be false for staked member', async () => {
+      await pillarToken
+        .connect(owner)
+        .approve(pillarDAO.address, stakingAmount);
+      await pillarDAO.deposit(stakingAmount);
+      const ret = await pillarDAO.canUnstake(owner.address);
+      expect(ret).to.equal(false);
+    });
+
+    it('canUnstake() - should be true for unstaked member', async () => {
+      const ret = await pillarDAO.canUnstake(owner.address);
+      expect(ret).to.equal(true);
+    });
   });
 
-  it('membershipId()', async () => {
-    const membershipId = await pillarDAO.membershipId(owner.address);
-    expect(membershipId).to.equal(1);
+  describe('Withdrawing', async () => {
+    it('withdraw() fails when not member', async () => {
+      const tran = pillarDAO.connect(addr1).withdraw();
+      await expect(tran).to.revertedWith(
+        'PillarDAO:: insufficient balance to withdraw'
+      );
+    });
+
+    it('withdraw() fails when tried early', async () => {
+      await pillarToken
+        .connect(owner)
+        .approve(pillarDAO.address, stakingAmount);
+      await pillarDAO.deposit(stakingAmount);
+      const tran = pillarDAO.withdraw();
+      await expect(tran).to.revertedWith('PillarDAO:: too early to withdraw');
+    });
+
+    it('withdraw() after 52 weeks', async () => {
+      await pillarToken
+        .connect(owner)
+        .approve(pillarDAO.address, stakingAmount);
+      await pillarDAO.deposit(stakingAmount);
+      await time.increase(secondsIn53Weeks);
+      const tran = await pillarDAO.withdraw();
+      const ret = await tran.wait();
+      const membershipId = await pillarDAO.membershipId(owner.address);
+      expect(ret.events.length).to.gte(0);
+      expect(membershipId).to.equal(0);
+    });
   });
 
-  it('canUnstake()', async () => {
-    const ret = await pillarDAO.canUnstake(owner.address);
-    expect(ret).to.equal(false);
-  });
-
-  it('withdraw() fails when not member', async () => {
-    const tran = pillarDAO.connect(addr1).withdraw();
-    await expect(tran).to.revertedWith(
-      'PillarDAO:: insufficient balance to withdraw'
-    );
-  });
-
-  it('withdraw() fails when tried early', async () => {
-    const tran = pillarDAO.withdraw();
-    await expect(tran).to.revertedWith('PillarDAO:: too early to withdraw');
-  });
-
-  it('configuration functions can be called only by owner', async () => {
-    const txn1 = pillarDAO.connect(addr2).setMembershipURI('test');
-    await expect(txn1).to.revertedWith('Ownable: caller is not the owner');
-  });
-
-  it('withdraw() after 52 weeks', async () => {
-    let now = new Date();
-    now.setDate(now.getDate() + 53 * 7);
-    const newTimestamp = Math.floor(now.getTime() / 1000);
-    await network.provider.send('evm_setNextBlockTimestamp', [newTimestamp]);
-    await network.provider.send('evm_mine');
-    const tran = await pillarDAO.withdraw();
-    const ret = await tran.wait();
-    const membershipId = await pillarDAO.membershipId(owner.address);
-    expect(ret.events.length).to.gte(0);
-    expect(membershipId).to.equal(0);
+  describe('Contract configurability', async () => {
+    it('configuration functions can be called only by owner', async () => {
+      const txn1 = pillarDAO.connect(addr2).setMembershipURI('test');
+      await expect(txn1).to.revertedWith('Ownable: caller is not the owner');
+    });
   });
 
   describe('#withdrawTokenToOwner', async () => {
@@ -150,6 +185,115 @@ describe('PillarDAO', () => {
       expect(daoPreBalance).eq(ethers.utils.parseEther('1'));
       expect(daoPreBalance).gt(daoPostBalance);
       expect(daoPostBalance).eq(0);
+    });
+  });
+
+  describe('check migration', async () => {
+    it('should add pre-existing members', async () => {
+      const deposit = ethers.utils.parseEther('10000');
+      const totalDeposits = ethers.utils.parseEther('90000');
+      // Pre-mint the MembershipNFTs
+      await membershipNFT.setVaultAddress(owner.address);
+      await membershipNFT.connect(owner).mint(members[0]);
+      await membershipNFT.connect(owner).mint(members[1]);
+      await membershipNFT.connect(owner).mint(members[2]);
+      await membershipNFT.connect(owner).mint(members[3]);
+      await membershipNFT.connect(owner).mint(members[4]);
+      await membershipNFT.connect(owner).mint(members[5]);
+      await membershipNFT.connect(owner).mint(members[6]);
+      await membershipNFT.connect(owner).mint(members[7]);
+      await membershipNFT.connect(owner).mint(members[8]);
+      await membershipNFT.setVaultAddress(pillarDAO.address);
+      // Membership ID check
+      expect(await pillarDAO.membershipId(members[0])).to.equal(1);
+      expect(await pillarDAO.membershipId(members[1])).to.equal(2);
+      expect(await pillarDAO.membershipId(members[2])).to.equal(3);
+      expect(await pillarDAO.membershipId(members[3])).to.equal(4);
+      expect(await pillarDAO.membershipId(members[4])).to.equal(5);
+      expect(await pillarDAO.membershipId(members[5])).to.equal(6);
+      expect(await pillarDAO.membershipId(members[6])).to.equal(7);
+      expect(await pillarDAO.membershipId(members[7])).to.equal(8);
+      expect(await pillarDAO.membershipId(members[8])).to.equal(9);
+      // Deposited balance check
+      expect(await pillarDAO.balanceOf(members[0])).to.equal(deposit);
+      expect(await pillarDAO.balanceOf(members[1])).to.equal(deposit);
+      expect(await pillarDAO.balanceOf(members[2])).to.equal(deposit);
+      expect(await pillarDAO.balanceOf(members[3])).to.equal(deposit);
+      expect(await pillarDAO.balanceOf(members[4])).to.equal(deposit);
+      expect(await pillarDAO.balanceOf(members[5])).to.equal(deposit);
+      expect(await pillarDAO.balanceOf(members[6])).to.equal(deposit);
+      expect(await pillarDAO.balanceOf(members[7])).to.equal(deposit);
+      expect(await pillarDAO.balanceOf(members[8])).to.equal(deposit);
+      // Deposit PLR tokens manually to cover
+      await pillarToken.connect(owner).approve(owner.address, totalDeposits);
+      await pillarToken
+        .connect(owner)
+        .transferFrom(owner.address, pillarDAO.address, totalDeposits);
+      expect(await pillarToken.balanceOf(pillarDAO.address)).to.equal(
+        totalDeposits
+      );
+      // Check withdrawal
+      await time.increase(secondsIn53Weeks);
+      // get pre-withdrawal balance
+      const pre1 = await pillarToken.balanceOf(members[0]);
+      const pre2 = await pillarToken.balanceOf(members[1]);
+      const pre3 = await pillarToken.balanceOf(members[2]);
+      const pre4 = await pillarToken.balanceOf(members[3]);
+      const pre5 = await pillarToken.balanceOf(members[4]);
+      const pre6 = await pillarToken.balanceOf(members[5]);
+      const pre7 = await pillarToken.balanceOf(members[6]);
+      const pre8 = await pillarToken.balanceOf(members[7]);
+      const pre9 = await pillarToken.balanceOf(members[8]);
+      // approve to burn NFT
+      await membershipNFT.connect(pm1).approve(pillarDAO.address, 1);
+      await membershipNFT.connect(pm2).approve(pillarDAO.address, 2);
+      await membershipNFT.connect(pm3).approve(pillarDAO.address, 3);
+      await membershipNFT.connect(pm4).approve(pillarDAO.address, 4);
+      await membershipNFT.connect(pm5).approve(pillarDAO.address, 5);
+      await membershipNFT.connect(pm6).approve(pillarDAO.address, 6);
+      await membershipNFT.connect(pm7).approve(pillarDAO.address, 7);
+      await membershipNFT.connect(pm8).approve(pillarDAO.address, 8);
+      await membershipNFT.connect(pm9).approve(pillarDAO.address, 9);
+      // withdraw
+      await pillarDAO.connect(pm1).withdraw();
+      await pillarDAO.connect(pm2).withdraw();
+      await pillarDAO.connect(pm3).withdraw();
+      await pillarDAO.connect(pm4).withdraw();
+      await pillarDAO.connect(pm5).withdraw();
+      await pillarDAO.connect(pm6).withdraw();
+      await pillarDAO.connect(pm7).withdraw();
+      await pillarDAO.connect(pm8).withdraw();
+      await pillarDAO.connect(pm9).withdraw();
+      // get post-withdrawal balance
+      const post1 = await pillarToken.balanceOf(members[0]);
+      const post2 = await pillarToken.balanceOf(members[1]);
+      const post3 = await pillarToken.balanceOf(members[2]);
+      const post4 = await pillarToken.balanceOf(members[3]);
+      const post5 = await pillarToken.balanceOf(members[4]);
+      const post6 = await pillarToken.balanceOf(members[5]);
+      const post7 = await pillarToken.balanceOf(members[6]);
+      const post8 = await pillarToken.balanceOf(members[7]);
+      const post9 = await pillarToken.balanceOf(members[8]);
+      // check PillarToken balance increased by stake amount
+      expect(pre1 + deposit).to.equal(post1);
+      expect(pre2 + deposit).to.equal(post2);
+      expect(pre3 + deposit).to.equal(post3);
+      expect(pre4 + deposit).to.equal(post4);
+      expect(pre5 + deposit).to.equal(post5);
+      expect(pre6 + deposit).to.equal(post6);
+      expect(pre7 + deposit).to.equal(post7);
+      expect(pre8 + deposit).to.equal(post8);
+      expect(pre9 + deposit).to.equal(post9);
+      // check MembershipNFT id is now 0
+      expect(await pillarDAO.membershipId(members[0])).to.equal(0);
+      expect(await pillarDAO.membershipId(members[1])).to.equal(0);
+      expect(await pillarDAO.membershipId(members[2])).to.equal(0);
+      expect(await pillarDAO.membershipId(members[3])).to.equal(0);
+      expect(await pillarDAO.membershipId(members[4])).to.equal(0);
+      expect(await pillarDAO.membershipId(members[5])).to.equal(0);
+      expect(await pillarDAO.membershipId(members[6])).to.equal(0);
+      expect(await pillarDAO.membershipId(members[7])).to.equal(0);
+      expect(await pillarDAO.membershipId(members[8])).to.equal(0);
     });
   });
 });


### PR DESCRIPTION
- Allows for passing in at deployment an existing array of accounts (for our specific use case). This will allow for any members that already exist to be migrated onto a new DAO contract. This expects a MembershipNFT contract to already be in use with an existing set of NFTs minted to those members.
- Addition of deployment script with setup for minting new members to existing MembershipNFT contract.
- Added test to mimic entire process through to withdrawal.
- Upgraded hardhat version to 2.13.0 and new hardhat-network-helpers package for testing time dependant tests.